### PR TITLE
Pass root env file to docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,13 @@ This repository hosts the Aurora POS platform, a clean-room, open-source grocery
 - [ ] Milestone 7 — Tests, Docs, Runbook
 
 Further documentation will expand alongside subsequent milestones.
+
+## Bringing the stack up
+
+To start all services locally, ensure you have Docker and Docker Compose installed, then run:
+
+```sh
+docker compose --env-file .env -f infra/docker-compose.yml up -d --build
+```
+
+The root `.env` file is passed to Compose so environment configuration can be centralized even though the compose file lives in `infra/`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,7 @@
 # Aurora POS Documentation
 
 This directory will house in-depth architecture notes, ADRs, and integration guides as the project evolves across milestones.
+
+> ℹ️ **Compose & environment files**
+>
+> Docker Compose resolves environment variables relative to the directory containing the compose file. Because the project keeps the primary `.env` in the repository root while the compose file lives in `infra/`, pass the root file explicitly when running Compose (e.g., `docker compose --env-file .env -f infra/docker-compose.yml up -d --build`).

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -5,4 +5,4 @@ if [ ! -f .env ]; then
   cp .env.example .env
 fi
 
-docker compose -f infra/docker-compose.yml up -d --build
+docker compose --env-file .env -f infra/docker-compose.yml up -d --build


### PR DESCRIPTION
## Summary
- update bootstrap script to pass the root .env into docker compose
- document the env-file flag in the main README instructions
- add ops note in docs clarifying how docker compose resolves env files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deeb9119c48321a7498ce64f10f118