### PR TITLE
Add backend Docker ignore for build artifacts

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,10 @@
+**/bin/
+**/obj/
+.vs/
+Dockerfile.*
+*.user
+*.suo
+.idea/
+.vscode/
+node_modules/
+.env


### PR DESCRIPTION
## Summary
- add a backend .dockerignore file to exclude build and IDE artifacts from the Docker context

## Testing
- ⚠️ `docker compose build backend` *(fails: docker command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68def53135708321bccbffb958aacf65