### PR TITLE
Use enumerable AddRangeAsync overload for user seeding

### DIFF
--- a/backend/src/PosBackend/Infrastructure/Data/SeedData.cs
+++ b/backend/src/PosBackend/Infrastructure/Data/SeedData.cs
@@ -35,7 +35,7 @@ public static class SeedData
                 PasswordHash = BCrypt.Net.BCrypt.HashPassword("ChangeMe123!")
             };
 
-            await db.Users.AddRangeAsync(admin, manager, cashier, cancellationToken);
+            await db.Users.AddRangeAsync(new[] { admin, manager, cashier }, cancellationToken);
         }
 
         if (!await db.Categories.AnyAsync(cancellationToken))


### PR DESCRIPTION
## Summary
- switch the user seeding logic to use the enumerable AddRangeAsync overload

## Testing
- `docker compose -f infra/docker-compose.yml build backend` *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68def69904908321a2d4430a3ae243b7