### PR TITLE
Align frontend container port with nginx listener

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,5 +10,5 @@ RUN npm run build
 
 FROM nginx:1.25-alpine
 COPY --from=build /app/dist /usr/share/nginx/html
-EXPOSE 4173
+EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       VITE_API_URL: ${FRONTEND_API_URL}
       VITE_ML_URL: ${FRONTEND_ML_URL}
     ports:
-      - "5173:4173"
+      - "5173:80"
     depends_on:
       - backend
 


### PR DESCRIPTION
## Summary
- update the frontend service port mapping to point host port 5173 at nginx's port 80
- expose port 80 from the frontend image to match nginx's default listener

## Testing
- `docker compose --env-file .env -f infra/docker-compose.yml up -d --build` *(fails: docker not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68def8e919a483219850a5d2eb8507de