### PR TITLE
Pin react-i18next to published release

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
     "i18next": "^23.7.11",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-i18next": "^13.5.1",
+    "react-i18next": "13.5.1",
     "react-router-dom": "^6.21.1",
     "recharts": "^2.10.3",
     "zustand": "^4.5.2"


### PR DESCRIPTION
## Summary
- pin the frontend dependency on react-i18next to the explicitly published 13.5.1 release

## Testing
- docker compose --env-file .env -f infra/docker-compose.yml build frontend *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68defbb2c9ec83218657797227e5e9ea