### PR TITLE
chore: align react-i18next version

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
     "i18next": "^23.7.11",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-i18next": "13.5.1",
+    "react-i18next": "13.5.0",
     "react-router-dom": "^6.21.1",
     "recharts": "^2.10.3",
     "zustand": "^4.5.2"


### PR DESCRIPTION
## Summary
- update the frontend react-i18next dependency to version 13.5.0

## Testing
- npm install *(fails: 403 Forbidden from registry in this environment)*
- docker build -t frontend-app . *(fails: docker command unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df8e3296608321a9afe5d39bd49fc6