### PR TITLE
Add migration attributes to initial migration

### DIFF
--- a/backend/src/PosBackend/Infrastructure/Data/Migrations/20240101000000_InitialCreate.cs
+++ b/backend/src/PosBackend/Infrastructure/Data/Migrations/20240101000000_InitialCreate.cs
@@ -1,10 +1,14 @@
 using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
+using PosBackend.Infrastructure.Data;
 
 #nullable disable
 
 namespace PosBackend.Infrastructure.Data.Migrations
 {
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20240101000000_InitialCreate")]
     public partial class InitialCreate : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)


### PR DESCRIPTION
## Summary
- add the missing DbContext and Migration attributes to the initial migration so EF can detect the ApplicationDbContext when applying migrations

## Testing
- not run (dotnet CLI unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dfa68640508321a78340adc63f78e0