### PR TITLE
Update backend JWT secret key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ POSTGRES_PASSWORD=aurora_pass
 BACKEND_DB_CONNECTION=Host=db;Port=5432;Database=aurora_pos;Username=aurora;Password=aurora_pass
 BACKEND_JWT_ISSUER=https://aurora-pos.local
 BACKEND_JWT_AUDIENCE=https://aurora-pos.local
-BACKEND_JWT_KEY=change_this_secret_key
+BACKEND_JWT_KEY=4zCsI0za1b2vWCUW0qFAxLZenDGXLzkaksjHEQUw8lU
 
 # Frontend
 FRONTEND_API_URL=http://localhost:5000

--- a/backend/src/PosBackend/appsettings.json
+++ b/backend/src/PosBackend/appsettings.json
@@ -12,7 +12,7 @@
   "Jwt": {
     "Issuer": "https://aurora-pos.local",
     "Audience": "https://aurora-pos.local",
-    "Key": "change_this_secret_key",
+    "Key": "4zCsI0za1b2vWCUW0qFAxLZenDGXLzkaksjHEQUw8lU",
     "ExpiryMinutes": 720
   },
   "MlService": {


### PR DESCRIPTION
## Summary
- replace the placeholder JWT signing secret with a new 32-byte value in the backend configuration and example environment file
- verified there were no committed .env files that also required the secret update

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfa9c4d7708321bbec0604fafd58b6