### PR TITLE
Refactor React Query hooks to new options object syntax

### DIFF
--- a/frontend/src/components/pos/ProductGrid.tsx
+++ b/frontend/src/components/pos/ProductGrid.tsx
@@ -30,14 +30,14 @@ export function ProductGrid({ onScan }: ProductGridProps) {
   const token = useAuthStore((state) => state.token);
   const addItem = useCartStore((state) => state.addItem);
 
-  const { data, refetch, isFetching } = useQuery<ProductResponse[]>(
-    ['products', term, token],
-    async () => {
+  const { data, refetch, isFetching } = useQuery<ProductResponse[]>({
+    queryKey: ['products', term, token],
+    queryFn: async () => {
       const searchParam = term ? `?q=${encodeURIComponent(term)}` : '?q=';
       return await apiFetch<ProductResponse[]>(`/api/products/search${searchParam}`, {}, token ?? undefined);
     },
-    { enabled: !!token }
-  );
+    enabled: !!token
+  });
 
   useEffect(() => {
     const handler = setTimeout(() => {

--- a/frontend/src/pages/AnalyticsPage.tsx
+++ b/frontend/src/pages/AnalyticsPage.tsx
@@ -135,14 +135,14 @@ export function AnalyticsPage() {
   const logout = useAuthStore((state) => state.logout);
   const navigate = useNavigate();
 
-  const { data, isLoading, isError } = useQuery(
-    ['analytics-dashboard', token],
-    async () => {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['analytics-dashboard', token],
+    queryFn: async () => {
       if (!token) throw new Error('Unauthorized');
       return await apiFetch<AnalyticsDashboardResponse>('/api/analytics/dashboard', {}, token);
     },
-    { enabled: !!token }
-  );
+    enabled: !!token
+  });
 
   const dashboard = data ?? demoDashboard;
 

--- a/frontend/src/pages/POSPage.tsx
+++ b/frontend/src/pages/POSPage.tsx
@@ -81,13 +81,18 @@ export function POSPage() {
     return () => window.removeEventListener('keydown', handler);
   }, []);
 
-  const scanMutation = useMutation(async (code: string) => {
-    if (!token) throw new Error('Not authenticated');
-    return await apiFetch<ProductResponse>('/api/products/scan', {
-      method: 'POST',
-      body: JSON.stringify({ barcode: code })
-    }, token);
-  }, {
+  const scanMutation = useMutation({
+    mutationFn: async (code: string) => {
+      if (!token) throw new Error('Not authenticated');
+      return await apiFetch<ProductResponse>(
+        '/api/products/scan',
+        {
+          method: 'POST',
+          body: JSON.stringify({ barcode: code })
+        },
+        token
+      );
+    },
     onSuccess: (product) => {
       addItem({
         productId: product.id,
@@ -108,10 +113,12 @@ export function POSPage() {
     }
   });
 
-  const currencyQuery = useQuery(['currency-rate', token], async () => {
-    if (!token) throw new Error('Not authenticated');
-    return await apiFetch<BalanceResponse>('/api/settings/currency-rate', {}, token);
-  }, {
+  const currencyQuery = useQuery({
+    queryKey: ['currency-rate', token],
+    queryFn: async () => {
+      if (!token) throw new Error('Not authenticated');
+      return await apiFetch<BalanceResponse>('/api/settings/currency-rate', {}, token);
+    },
     enabled: !!token,
     onSuccess: (data) => {
       setRate(data.exchangeRate);
@@ -119,13 +126,18 @@ export function POSPage() {
     }
   });
 
-  const computeBalance = useMutation(async (payload: { totalUsd: number; paidUsd: number; paidLbp: number; exchangeRate?: number }) => {
-    if (!token) throw new Error('Not authenticated');
-    return await apiFetch<BalanceResponse>('/api/transactions/compute-balance', {
-      method: 'POST',
-      body: JSON.stringify(payload)
-    }, token);
-  }, {
+  const computeBalance = useMutation({
+    mutationFn: async (payload: { totalUsd: number; paidUsd: number; paidLbp: number; exchangeRate?: number }) => {
+      if (!token) throw new Error('Not authenticated');
+      return await apiFetch<BalanceResponse>(
+        '/api/transactions/compute-balance',
+        {
+          method: 'POST',
+          body: JSON.stringify(payload)
+        },
+        token
+      );
+    },
     onSuccess: (data) => setBalance(data)
   });
 


### PR DESCRIPTION
## Summary
- refactor POS page mutations and queries to use the options-object signature
- update product grid and analytics queries to align with React Query's options API
- keep currency rate and balance handling logic intact with onSuccess callbacks

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfade9b7b48321a30415a1d496fe27