### PR TITLE
Make POS checkout column sticky

### DIFF
--- a/frontend/src/pages/POSPage.tsx
+++ b/frontend/src/pages/POSPage.tsx
@@ -239,26 +239,24 @@ export function POSPage() {
         <div className="lg:col-span-2">
           <ProductGrid onScan={(product) => setLastScan(`${product.name} (${product.sku})`)} />
         </div>
-        <div className="flex max-h-[calc(100vh-8rem)] flex-col gap-4">
+        <div className="flex max-h-[calc(100vh-8rem)] flex-col gap-4 lg:sticky lg:top-24">
           <div className="flex-1 overflow-y-auto">
             <CartPanel onClear={clear} />
           </div>
-          <div className="flex flex-col gap-4 lg:sticky lg:top-24">
-            <TenderPanel
-              paidUsd={paidUsd}
-              paidLbp={paidLbp}
-              onChangePaidUsd={setPaidUsd}
-              onChangePaidLbp={setPaidLbp}
-              onCheckout={handleCheckout}
-              balanceUsd={balance?.balanceUsd ?? 0}
-              balanceLbp={balance?.balanceLbp ?? 0}
-              exchangeRate={rate}
-              onOpenRateModal={() => canEditRate && setRateModalOpen(true)}
-              canEditRate={canEditRate}
-              disabled={overrideRequired}
-            />
-            <ReceiptPreview />
-          </div>
+          <TenderPanel
+            paidUsd={paidUsd}
+            paidLbp={paidLbp}
+            onChangePaidUsd={setPaidUsd}
+            onChangePaidLbp={setPaidLbp}
+            onCheckout={handleCheckout}
+            balanceUsd={balance?.balanceUsd ?? 0}
+            balanceLbp={balance?.balanceLbp ?? 0}
+            exchangeRate={rate}
+            onOpenRateModal={() => canEditRate && setRateModalOpen(true)}
+            canEditRate={canEditRate}
+            disabled={overrideRequired}
+          />
+          <ReceiptPreview />
         </div>
       </div>
       <CurrencyRateModal


### PR DESCRIPTION
## Summary
- keep the POS checkout column pinned beneath the top bar on large screens
- allow the cart contents to scroll independently of the checkout and receipt panels

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfb4fca3cc83218044326836770479