### PR TITLE
Add remove controls to receipt preview items

### DIFF
--- a/frontend/src/components/pos/ReceiptPreview.tsx
+++ b/frontend/src/components/pos/ReceiptPreview.tsx
@@ -1,12 +1,34 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import type { SVGProps } from 'react';
 import { Card, CardContent, CardTitle } from '../ui/card';
 import { useCartStore } from '../../stores/cartStore';
 import { formatCurrency } from '../../lib/utils';
 
+function TrashIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M3 6h18" />
+      <path d="M8 6V4.5A1.5 1.5 0 0 1 9.5 3h5A1.5 1.5 0 0 1 16 4.5V6" />
+      <path d="M18 6v13a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V6" />
+      <path d="M10 11v6" />
+      <path d="M14 11v6" />
+    </svg>
+  );
+}
+
 export function ReceiptPreview() {
   const { t, i18n } = useTranslation();
-  const { items, subtotalUsd, subtotalLbp } = useCartStore();
+  const { items, subtotalUsd, subtotalLbp, removeItem } = useCartStore();
 
   const lines = useMemo(
     () =>
@@ -23,11 +45,27 @@ export function ReceiptPreview() {
         <CardTitle className="mb-4 text-center text-base font-semibold">{t('receiptPreview')}</CardTitle>
         <div className="space-y-2">
           {lines.map((line) => (
-            <div key={line.productId} className="flex justify-between border-b border-dashed border-slate-200 pb-1 text-xs dark:border-slate-700">
-              <span>{line.name}</span>
-              <span>
-                {line.quantity} × {formatCurrency(line.priceUsd, 'USD', i18n.language === 'ar' ? 'ar-LB' : 'en-US')}
+            <div
+              key={line.productId}
+              className="flex items-start justify-between border-b border-dashed border-slate-200 pb-1 text-xs dark:border-slate-700"
+            >
+              <span className="max-w-[60%] truncate" title={line.name}>
+                {line.name}
               </span>
+              <div className="flex items-center gap-2 text-right">
+                <span>
+                  {line.quantity} ×{' '}
+                  {formatCurrency(line.priceUsd, 'USD', i18n.language === 'ar' ? 'ar-LB' : 'en-US')}
+                </span>
+                <button
+                  type="button"
+                  className="flex h-7 w-7 items-center justify-center rounded-full border border-red-200 text-red-600 transition hover:border-red-300 hover:bg-red-50 hover:text-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 focus:ring-offset-white dark:border-red-500/40 dark:text-red-300 dark:hover:border-red-400 dark:hover:bg-red-900/30 dark:hover:text-red-200 dark:focus:ring-offset-slate-900"
+                  aria-label={t('removeItem')}
+                  onClick={() => removeItem(line.productId)}
+                >
+                  <TrashIcon className="h-3.5 w-3.5" />
+                </button>
+              </div>
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- pull the cart store remove handler into the receipt preview
- add an accessible remove control to each receipt line item so the cart updates immediately

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfbea80e588321955108c69b2f8ae5