### PR TITLE
Reposition checkout panel on POS page layout

### DIFF
--- a/frontend/src/pages/POSPage.tsx
+++ b/frontend/src/pages/POSPage.tsx
@@ -225,38 +225,38 @@ export function POSPage() {
         lastScan={lastScan}
         onNavigateAnalytics={canSeeAnalytics ? () => navigate('/analytics') : undefined}
       />
-      <form onSubmit={handleScanSubmit} className="flex items-center gap-3">
-        <Input
-          id="barcode-input"
-          value={barcode}
-          onChange={(event) => setBarcode(event.target.value)}
-          placeholder={t('barcodePlaceholder')}
-          className="text-lg"
+      <section className="w-full">
+        <TenderPanel
+          paidUsd={paidUsd}
+          paidLbp={paidLbp}
+          onChangePaidUsd={setPaidUsd}
+          onChangePaidLbp={setPaidLbp}
+          onCheckout={handleCheckout}
+          balanceUsd={balance?.balanceUsd ?? 0}
+          balanceLbp={balance?.balanceLbp ?? 0}
+          exchangeRate={rate}
+          onOpenRateModal={() => canEditRate && setRateModalOpen(true)}
+          canEditRate={canEditRate}
+          disabled={overrideRequired}
         />
-        <Button type="submit">Scan</Button>
-      </form>
+      </section>
       <div className="grid gap-4 lg:grid-cols-3">
-        <div className="lg:col-span-2">
+        <div className="space-y-4 lg:col-span-2">
+          <form onSubmit={handleScanSubmit} className="flex items-center gap-3">
+            <Input
+              id="barcode-input"
+              value={barcode}
+              onChange={(event) => setBarcode(event.target.value)}
+              placeholder={t('barcodePlaceholder')}
+              className="text-lg"
+            />
+            <Button type="submit">Scan</Button>
+          </form>
           <ProductGrid onScan={(product) => setLastScan(`${product.name} (${product.sku})`)} />
         </div>
-        <div className="flex max-h-[calc(100vh-8rem)] flex-col gap-4">
+        <div className="flex max-h-[calc(100vh-16rem)] flex-col gap-4 lg:sticky lg:top-24">
           <div className="flex-1 overflow-y-auto">
             <CartPanel onClear={clear} />
-          </div>
-          <div className="lg:sticky lg:top-24 space-y-4">
-            <TenderPanel
-              paidUsd={paidUsd}
-              paidLbp={paidLbp}
-              onChangePaidUsd={setPaidUsd}
-              onChangePaidLbp={setPaidLbp}
-              onCheckout={handleCheckout}
-              balanceUsd={balance?.balanceUsd ?? 0}
-              balanceLbp={balance?.balanceLbp ?? 0}
-              exchangeRate={rate}
-              onOpenRateModal={() => canEditRate && setRateModalOpen(true)}
-              canEditRate={canEditRate}
-              disabled={overrideRequired}
-            />
           </div>
           <ReceiptPreview />
         </div>


### PR DESCRIPTION
## Summary
- move the TenderPanel into its own full-width section directly under the POS header
- update the grid column layout so the scanner form and product grid retain spacing after the move
- adjust the cart and receipt column styling to preserve sticky behavior without the checkout panel

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68dfc4a3528c832195fc87b7403a41db