### PR TITLE
Adjust POS cart layout for wider cart column

### DIFF
--- a/frontend/src/pages/POSPage.tsx
+++ b/frontend/src/pages/POSPage.tsx
@@ -240,7 +240,7 @@ export function POSPage() {
           disabled={overrideRequired}
         />
       </section>
-      <div className="grid gap-4 lg:grid-cols-3">
+      <div className="grid gap-4 lg:grid-cols-4">
         <div className="space-y-4 lg:col-span-2">
           <form onSubmit={handleScanSubmit} className="flex items-center gap-3">
             <Input
@@ -254,11 +254,13 @@ export function POSPage() {
           </form>
           <ProductGrid onScan={(product) => setLastScan(`${product.name} (${product.sku})`)} />
         </div>
-        <div className="flex max-h-[calc(100vh-16rem)] flex-col gap-4 lg:sticky lg:top-24">
-          <div className="flex-1 overflow-y-auto">
+        <div className="flex h-full flex-col gap-4 lg:col-span-2 lg:sticky lg:top-24 lg:max-h-[calc(100vh-16rem)]">
+          <section className="flex-1 overflow-y-auto">
             <CartPanel onClear={clear} />
+          </section>
+          <div className="mt-auto">
+            <ReceiptPreview />
           </div>
-          <ReceiptPreview />
         </div>
       </div>
       <CurrencyRateModal


### PR DESCRIPTION
## Summary
- widen the POS page grid to dedicate two columns to the cart and checkout area
- maintain scrollable cart content while pinning the receipt preview to the column bottom

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68dfc8109c008321a1fcde073003dca2