### PR TITLE
Adjust POS cart layout sizing

### DIFF
--- a/frontend/src/pages/POSPage.tsx
+++ b/frontend/src/pages/POSPage.tsx
@@ -240,8 +240,8 @@ export function POSPage() {
           disabled={overrideRequired}
         />
       </section>
-      <div className="grid gap-4 lg:grid-cols-4">
-        <div className="space-y-4 lg:col-span-2">
+      <div className="grid gap-4 lg:grid-cols-[2fr_1fr]">
+        <div className="space-y-4">
           <form onSubmit={handleScanSubmit} className="flex items-center gap-3">
             <Input
               id="barcode-input"
@@ -254,7 +254,7 @@ export function POSPage() {
           </form>
           <ProductGrid onScan={(product) => setLastScan(`${product.name} (${product.sku})`)} />
         </div>
-        <div className="flex h-[calc(100vh-12rem)] flex-col gap-4 lg:col-span-2 lg:sticky lg:top-24">
+        <div className="flex h-[calc(100vh-12rem)] flex-col gap-4 lg:sticky lg:top-24">
           <div className="flex-1 overflow-hidden">
             <CartPanel onClear={clear} />
           </div>


### PR DESCRIPTION
## Summary
- narrow the POS page grid to give the cart column a smaller width and anchor the receipt preview to the bottom
- keep the cart panel flexible with its content contained so items scroll within the taller column

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfcd253da48321ba7e6641c4dca464