### PR TITLE
Refine POS layout with sticky checkout column

### DIFF
--- a/frontend/src/components/pos/CartPanel.tsx
+++ b/frontend/src/components/pos/CartPanel.tsx
@@ -28,20 +28,19 @@ export function CartPanel({ onClear }: CartPanelProps) {
 
   return (
     <Card className="flex h-full flex-col bg-slate-50 dark:bg-slate-900">
-      <CardHeader>
+      <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <CardTitle>{t('cart')}</CardTitle>
         <Button type="button" className="bg-slate-600 hover:bg-slate-500" onClick={onClear}>
           {t('clearCart')}
         </Button>
       </CardHeader>
-      <CardContent className="flex-1 overflow-hidden">
-        <div className="flex h-full flex-col">
-          <div className="flex-1 overflow-y-auto space-y-3">
-            {items.map((item) => (
-              <div
-                key={item.productId}
-                className="rounded-lg border border-slate-200 bg-white p-3 shadow-sm dark:border-slate-700 dark:bg-slate-800"
-              >
+      <CardContent className="flex flex-1 flex-col overflow-hidden">
+        <div className="flex-1 space-y-3 overflow-y-auto pr-1">
+          {items.map((item) => (
+            <div
+              key={item.productId}
+              className="rounded-lg border border-slate-200 bg-white p-3 shadow-sm dark:border-slate-700 dark:bg-slate-800"
+            >
                 <div className="flex items-start justify-between">
                   <div>
                     <p className="font-semibold">{item.name}</p>
@@ -91,15 +90,14 @@ export function CartPanel({ onClear }: CartPanelProps) {
             ))}
             {items.length === 0 && <p className="text-center text-sm text-slate-500">Cart empty</p>}
           </div>
-          <div className="mt-4 rounded-lg border border-slate-200 bg-white p-3 text-sm dark:border-slate-700 dark:bg-slate-800">
-            <div className="flex justify-between">
-              <span>{t('total')} USD</span>
-              <span className="font-semibold">{formatCurrency(subtotalUsd(), 'USD', i18n.language === 'ar' ? 'ar-LB' : 'en-US')}</span>
-            </div>
-            <div className="flex justify-between">
-              <span>{t('total')} LBP</span>
-              <span className="font-semibold">{formatCurrency(subtotalLbp(), 'LBP', i18n.language === 'ar' ? 'ar-LB' : 'en-US')}</span>
-            </div>
+        <div className="mt-4 rounded-lg border border-slate-200 bg-white p-3 text-sm dark:border-slate-700 dark:bg-slate-800">
+          <div className="flex justify-between">
+            <span>{t('total')} USD</span>
+            <span className="font-semibold">{formatCurrency(subtotalUsd(), 'USD', i18n.language === 'ar' ? 'ar-LB' : 'en-US')}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>{t('total')} LBP</span>
+            <span className="font-semibold">{formatCurrency(subtotalLbp(), 'LBP', i18n.language === 'ar' ? 'ar-LB' : 'en-US')}</span>
           </div>
         </div>
       </CardContent>

--- a/frontend/src/components/pos/ReceiptPreview.tsx
+++ b/frontend/src/components/pos/ReceiptPreview.tsx
@@ -1,0 +1,53 @@
+import { useTranslation } from 'react-i18next';
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
+import { useCartStore } from '../../stores/cartStore';
+import { formatCurrency } from '../../lib/utils';
+
+export function ReceiptPreview() {
+  const { t, i18n } = useTranslation();
+  const { items, subtotalUsd, subtotalLbp } = useCartStore();
+  const locale = i18n.language === 'ar' ? 'ar-LB' : 'en-US';
+
+  return (
+    <Card className="bg-slate-50 text-sm dark:bg-slate-900">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base font-semibold text-slate-700 dark:text-slate-100">
+          {t('receiptPreview')}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="max-h-32 space-y-2 overflow-y-auto pr-1">
+          {items.length > 0 ? (
+            items.map((item) => (
+              <div key={item.productId} className="flex items-start justify-between gap-2">
+                <div className="flex-1">
+                  <p className="truncate font-medium text-slate-700 dark:text-slate-200">{item.name}</p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">x{item.quantity}</p>
+                </div>
+                <p className="text-xs font-semibold text-slate-600 dark:text-slate-200">
+                  {formatCurrency(item.priceUsd * item.quantity * (1 - item.discountPercent / 100), 'USD', locale)}
+                </p>
+              </div>
+            ))
+          ) : (
+            <p className="text-xs text-slate-500 dark:text-slate-400">{t('barcodePlaceholder')}</p>
+          )}
+        </div>
+        <div className="space-y-1 text-xs text-slate-600 dark:text-slate-300">
+          <div className="flex justify-between">
+            <span>{t('total')} USD</span>
+            <span className="font-semibold">
+              {formatCurrency(subtotalUsd(), 'USD', locale)}
+            </span>
+          </div>
+          <div className="flex justify-between">
+            <span>{t('total')} LBP</span>
+            <span className="font-semibold">
+              {formatCurrency(subtotalLbp(), 'LBP', locale)}
+            </span>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- shrink the POS grid utility column, keeping tender controls sticky and anchoring a new receipt preview at the bottom
- wrap the cart panel in a dedicated flex container so it fills the column and scrolls without displacing other widgets
- add a lightweight receipt preview card that mirrors the current cart contents and totals

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dfda146e288321ac1d96891c01bc67