### PR TITLE
Resolve NotFound naming conflict in ProductServiceResult

### DIFF
--- a/backend/src/PosBackend/Application/Services/ProductService.cs
+++ b/backend/src/PosBackend/Application/Services/ProductService.cs
@@ -197,14 +197,14 @@ public class ProductService
 public class ProductServiceResult
 {
     public bool Succeeded { get; }
-    public bool NotFound { get; }
+    public bool IsNotFound { get; }
     public Product? Product { get; }
     public IReadOnlyDictionary<string, string[]> Errors { get; }
 
     private ProductServiceResult(bool succeeded, bool notFound, Product? product, IReadOnlyDictionary<string, string[]> errors)
     {
         Succeeded = succeeded;
-        NotFound = notFound;
+        IsNotFound = notFound;
         Product = product;
         Errors = errors;
     }

--- a/backend/src/PosBackend/Features/Products/ProductsController.cs
+++ b/backend/src/PosBackend/Features/Products/ProductsController.cs
@@ -32,7 +32,7 @@ public class ProductsController : ControllerBase
         var result = await _productService.CreateAsync(request, cancellationToken);
         if (!result.Succeeded)
         {
-            if (result.NotFound)
+            if (result.IsNotFound)
             {
                 return NotFound();
             }
@@ -56,7 +56,7 @@ public class ProductsController : ControllerBase
     public async Task<ActionResult<ProductResponse>> UpdateProduct(Guid id, [FromBody] CreateProductRequest request, CancellationToken cancellationToken)
     {
         var result = await _productService.UpdateAsync(id, request, cancellationToken);
-        if (result.NotFound)
+        if (result.IsNotFound)
         {
             return NotFound();
         }


### PR DESCRIPTION
## Summary
- rename the ProductServiceResult boolean property to IsNotFound so it no longer conflicts with the static helper
- update ProductsController to check the renamed property

## Testing
- dotnet publish *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0218759808321b8883dc0a549abb0