### PR TITLE
Adjust POS layout and product grid

### DIFF
--- a/frontend/src/components/pos/ProductGrid.tsx
+++ b/frontend/src/components/pos/ProductGrid.tsx
@@ -41,35 +41,37 @@ export function ProductGrid({ onScan }: ProductGridProps) {
   };
 
   return (
-    <div className="space-y-3">
+    <div className="flex h-full flex-col gap-2.5">
       <Input
         placeholder={t('searchProducts')}
         value={term}
         onChange={(event) => setTerm(event.target.value)}
         autoFocus
-        className="text-lg"
+        className="text-base"
       />
-      <div className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-4">
-        {data?.map((product) => (
-          <button
-            key={product.id}
-            onClick={() => handleAdd(product)}
-            className={cn(
-              'rounded-lg border border-slate-200 bg-white p-3 text-left shadow-sm transition focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-800',
-              'hover:border-emerald-500'
-            )}
-          >
-            <div className="flex items-center justify-between">
-              <p className="font-semibold">{product.name}</p>
-              <span className="text-xs text-slate-500">{product.sku}</span>
-            </div>
-            <p className="mt-2 text-sm text-emerald-600 dark:text-emerald-300">
-              {formatCurrency(product.priceUsd, 'USD', i18n.language === 'ar' ? 'ar-LB' : 'en-US')}
-            </p>
-            <p className="text-xs text-slate-500">{product.category}</p>
-          </button>
-        ))}
-        {isFetching && <Card className="col-span-full text-center text-sm text-slate-500">Loading…</Card>}
+      <div className="relative flex-1 overflow-hidden">
+        <div className="grid max-h-[26rem] grid-cols-2 gap-2.5 overflow-y-auto pr-1 sm:max-h-[30rem] sm:grid-cols-2 md:grid-cols-3 lg:max-h-[32rem] lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+          {data?.map((product) => (
+            <button
+              key={product.id}
+              onClick={() => handleAdd(product)}
+              className={cn(
+                'rounded-md border border-slate-200 bg-white p-2.5 text-left text-sm shadow-sm transition focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-800',
+                'hover:border-emerald-500'
+              )}
+            >
+              <div className="flex items-center justify-between gap-1">
+                <p className="truncate font-medium">{product.name}</p>
+                <span className="text-[0.7rem] text-slate-500">{product.sku}</span>
+              </div>
+              <p className="mt-1 text-xs text-emerald-600 dark:text-emerald-300">
+                {formatCurrency(product.priceUsd, 'USD', i18n.language === 'ar' ? 'ar-LB' : 'en-US')}
+              </p>
+              <p className="text-[0.7rem] text-slate-500">{product.category}</p>
+            </button>
+          ))}
+          {isFetching && <Card className="col-span-full text-center text-xs text-slate-500">Loading…</Card>}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/POSPage.tsx
+++ b/frontend/src/pages/POSPage.tsx
@@ -224,7 +224,7 @@ export function POSPage() {
   };
 
   return (
-    <div className="flex min-h-screen flex-col gap-4 bg-slate-100 p-4 dark:bg-slate-950">
+    <div className="flex min-h-screen flex-col gap-3 bg-slate-100 p-4 lg:p-6 dark:bg-slate-950">
       <TopBar
         onLogout={logout}
         lastScan={lastScan}
@@ -232,21 +232,25 @@ export function POSPage() {
         onNavigateInventory={canManageInventory ? () => navigate('/inventory') : undefined}
         onNavigateSettings={canManageInventory ? () => navigate('/settings') : undefined}
       />
-      <div className="grid gap-4 lg:grid-cols-[2.5fr_1fr]">
-        <div className="space-y-4">
-          <form onSubmit={handleScanSubmit} className="flex items-center gap-3">
+      <div className="grid gap-3 lg:grid-cols-[1.75fr_1fr] xl:grid-cols-[1.65fr_1fr]">
+        <div className="flex min-h-0 flex-col gap-3 lg:pr-2">
+          <form onSubmit={handleScanSubmit} className="flex items-center gap-2.5">
             <Input
               id="barcode-input"
               value={barcode}
               onChange={(event) => setBarcode(event.target.value)}
               placeholder={t('barcodePlaceholder')}
-              className="text-lg"
+              className="text-base"
             />
-            <Button type="submit">Scan</Button>
+            <Button type="submit" size="sm">
+              Scan
+            </Button>
           </form>
-          <ProductGrid onScan={(product) => setLastScan(`${product.name} (${product.sku})`)} />
+          <div className="flex-1 overflow-hidden">
+            <ProductGrid onScan={(product) => setLastScan(`${product.name} (${product.sku})`)} />
+          </div>
         </div>
-        <div className="flex h-[calc(100vh-12rem)] max-w-sm flex-col gap-4 lg:justify-between">
+        <div className="flex h-[calc(100vh-11rem)] max-w-md flex-col gap-3 lg:justify-between">
           <div className="lg:sticky lg:top-24">
             <TenderPanel
               paidUsd={paidUsd}
@@ -265,7 +269,7 @@ export function POSPage() {
           <div className="flex-1 overflow-hidden">
             <CartPanel onClear={clear} />
           </div>
-          <div className="mt-auto">
+          <div className="mt-auto pt-1">
             <ReceiptPreview />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- rebalance the POS page layout to allocate more room to the tender and cart panels while tightening spacing
- wrap the product grid in a scrollable container and reduce control sizing for a more compact footprint
- tweak product card styling and responsive column counts to improve readability across breakpoints

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0f3cb019083219c22e4b5b3b818e4