### PR TITLE
feat: streamline quantity edits after scanning

### DIFF
--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,14 +1,17 @@
+import { forwardRef, type InputHTMLAttributes } from 'react';
 import { cn } from '../../lib/utils';
-import type { InputHTMLAttributes } from 'react';
 
-export function Input({ className, ...props }: InputHTMLAttributes<HTMLInputElement>) {
-  return (
+export const Input = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(
+  ({ className, ...props }, ref) => (
     <input
+      ref={ref}
       className={cn(
         'w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100',
         className
       )}
       {...props}
     />
-  );
-}
+  )
+);
+
+Input.displayName = 'Input';


### PR DESCRIPTION
## Summary
- track the last-added cart item and add a direct quantity setter in the cart store
- focus the most recently scanned item in the POS cart to prompt quantity entry after scans
- highlight the targeted cart row, clamp quantity inputs, handle enter key confirms, and forward refs through the shared input component

## Testing
- npm run lint *(fails: InventoryPage.tsx storeName is assigned but never used)*

------
https://chatgpt.com/codex/tasks/task_e_68e0f494169083218ee494f9acb22ff7