### PR TITLE
Use async receipt rendering in transactions controller

### DIFF
--- a/backend/src/PosBackend/Features/Transactions/TransactionsController.cs
+++ b/backend/src/PosBackend/Features/Transactions/TransactionsController.cs
@@ -188,6 +188,8 @@ public class TransactionsController : ControllerBase
             Lines = lines.Select(l => new { l.ProductId, l.Quantity })
         }, cancellationToken);
 
+        var receiptBytes = await _receiptRenderer.RenderPdfAsync(transaction, lines, transaction.ExchangeRateUsed, cancellationToken);
+
         return new CheckoutResponse
         {
             TransactionId = transaction.Id,
@@ -200,7 +202,7 @@ public class TransactionsController : ControllerBase
             BalanceLbp = 0,
             ExchangeRate = transaction.ExchangeRateUsed,
             Lines = lines,
-            ReceiptPdfBase64 = Convert.ToBase64String(_receiptRenderer.RenderPdf(transaction, lines, transaction.ExchangeRateUsed))
+            ReceiptPdfBase64 = Convert.ToBase64String(receiptBytes)
         };
     }
 
@@ -235,11 +237,11 @@ public class TransactionsController : ControllerBase
             return NotFound();
         }
 
-        var pdf = _receiptRenderer.RenderPdf(transaction, transaction.Lines, transaction.ExchangeRateUsed);
+        var pdfBytes = await _receiptRenderer.RenderPdfAsync(transaction, transaction.Lines, transaction.ExchangeRateUsed, cancellationToken);
         return new ReceiptResponse
         {
             TransactionId = transaction.Id,
-            PdfBase64 = Convert.ToBase64String(pdf)
+            PdfBase64 = Convert.ToBase64String(pdfBytes)
         };
     }
 }


### PR DESCRIPTION
## Summary
- update the return endpoint to await asynchronous receipt rendering before encoding to Base64
- update the receipt endpoint to use the asynchronous renderer and encode the resulting bytes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0f77b45e48321987a3b9cadb41e55