### PR TITLE
Add IsPinned support to product workflows

### DIFF
--- a/backend/src/PosBackend/Application/Requests/ProductMutationRequestBase.cs
+++ b/backend/src/PosBackend/Application/Requests/ProductMutationRequestBase.cs
@@ -23,4 +23,6 @@ public abstract class ProductMutationRequestBase
 
     [Required]
     public Guid CategoryId { get; set; }
+
+    public bool IsPinned { get; set; }
 }

--- a/backend/src/PosBackend/Application/Responses/ProductResponse.cs
+++ b/backend/src/PosBackend/Application/Responses/ProductResponse.cs
@@ -10,6 +10,7 @@ public class ProductResponse
     public decimal PriceLbp { get; set; }
     public string? Description { get; set; }
     public string Category { get; set; } = string.Empty;
+    public bool IsPinned { get; set; }
     public bool? IsFlagged { get; set; }
     public string? FlagReason { get; set; }
 }

--- a/backend/src/PosBackend/Domain/Entities/Product.cs
+++ b/backend/src/PosBackend/Domain/Entities/Product.cs
@@ -11,6 +11,7 @@ public class Product : BaseEntity
     public decimal PriceUsd { get; set; }
     public decimal PriceLbp { get; set; }
     public bool IsActive { get; set; } = true;
+    public bool IsPinned { get; set; }
     public ICollection<ExpirationBatch> ExpirationBatches { get; set; } = new List<ExpirationBatch>();
     public Inventory? Inventory { get; set; }
     public ICollection<PriceRule> PriceRules { get; set; } = new List<PriceRule>();

--- a/backend/src/PosBackend/Infrastructure/Data/Configurations/ProductConfiguration.cs
+++ b/backend/src/PosBackend/Infrastructure/Data/Configurations/ProductConfiguration.cs
@@ -13,5 +13,8 @@ public class ProductConfiguration : IEntityTypeConfiguration<Product>
         builder.HasIndex(p => p.Barcode).IsUnique();
         builder.Property(p => p.PriceUsd).HasColumnType("numeric(12,2)");
         builder.Property(p => p.PriceLbp).HasColumnType("numeric(14,2)");
+        builder.Property(p => p.IsPinned)
+            .HasColumnName("is_pinned")
+            .HasDefaultValue(false);
     }
 }

--- a/backend/src/PosBackend/Infrastructure/Data/Migrations/20240425000002_AddProductIsPinned.cs
+++ b/backend/src/PosBackend/Infrastructure/Data/Migrations/20240425000002_AddProductIsPinned.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using PosBackend.Infrastructure.Data;
+
+#nullable disable
+
+namespace PosBackend.Infrastructure.Data.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20240425000002_AddProductIsPinned")]
+    public partial class AddProductIsPinned : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "is_pinned",
+                table: "products",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "is_pinned",
+                table: "products");
+        }
+    }
+}

--- a/backend/src/PosBackend/Infrastructure/Data/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/src/PosBackend/Infrastructure/Data/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -124,6 +124,7 @@ namespace PosBackend.Infrastructure.Data.Migrations
                 b.Property<DateTime>("CreatedAt").HasColumnType("timestamp with time zone");
                 b.Property<string>("Description").HasColumnType("text");
                 b.Property<bool>("IsActive").HasColumnType("boolean");
+                b.Property<bool>("IsPinned").HasColumnName("is_pinned").HasColumnType("boolean").HasDefaultValue(false);
                 b.Property<string>("Name").HasColumnType("text");
                 b.Property<decimal>("PriceLbp").HasColumnType("numeric(14,2)");
                 b.Property<decimal>("PriceUsd").HasColumnType("numeric(12,2)");

--- a/backend/src/PosBackend/Infrastructure/Data/SeedData.cs
+++ b/backend/src/PosBackend/Infrastructure/Data/SeedData.cs
@@ -72,7 +72,8 @@ public static class SeedData
                         Barcode = random.NextInt64(1000000000000, 9999999999999).ToString(),
                         PriceUsd = priceUsd,
                         PriceLbp = priceUsd * 90000m,
-                        Description = $"Sample {category.Name} product {i}"
+                        Description = $"Sample {category.Name} product {i}",
+                        IsPinned = i == 1
                     };
                     products.Add(product);
 


### PR DESCRIPTION
## Summary
- add an `IsPinned` flag across the product entity, EF configuration, migration, and seed data
- surface the flag through product mutation requests, controller responses, and a `pinnedOnly` search filter

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0fc1be55c8321b729fbc46da283ce