### PR TITLE
Align POS tender panel with top bar styling

### DIFF
--- a/frontend/src/pages/POSPage.tsx
+++ b/frontend/src/pages/POSPage.tsx
@@ -236,22 +236,20 @@ export function POSPage() {
         onNavigateInventory={canManageInventory ? () => navigate('/inventory') : undefined}
         onNavigateSettings={canManageInventory ? () => navigate('/settings') : undefined}
       />
-      <div className="mt-3 flex w-full justify-center lg:mt-4 lg:justify-end">
-        <div className="w-full max-w-md">
-          <TenderPanel
-            paidUsd={paidUsd}
-            paidLbp={paidLbp}
-            onChangePaidUsd={setPaidUsd}
-            onChangePaidLbp={setPaidLbp}
-            onCheckout={handleCheckout}
-            balanceUsd={balance?.balanceUsd ?? 0}
-            balanceLbp={balance?.balanceLbp ?? 0}
-            exchangeRate={rate}
-            onOpenRateModal={() => canEditRate && setRateModalOpen(true)}
-            canEditRate={canEditRate}
-            disabled={overrideRequired}
-          />
-        </div>
+      <div className="rounded-xl bg-white p-4 shadow-sm dark:bg-slate-900">
+        <TenderPanel
+          paidUsd={paidUsd}
+          paidLbp={paidLbp}
+          onChangePaidUsd={setPaidUsd}
+          onChangePaidLbp={setPaidLbp}
+          onCheckout={handleCheckout}
+          balanceUsd={balance?.balanceUsd ?? 0}
+          balanceLbp={balance?.balanceLbp ?? 0}
+          exchangeRate={rate}
+          onOpenRateModal={() => canEditRate && setRateModalOpen(true)}
+          canEditRate={canEditRate}
+          disabled={overrideRequired}
+        />
       </div>
       <div className="grid gap-3 lg:grid-cols-[1.75fr_1fr] xl:grid-cols-[1.65fr_1fr]">
         <div className="flex min-h-0 flex-col gap-3 lg:pr-2">


### PR DESCRIPTION
## Summary
- restyle the POS checkout panel to reuse the top bar card treatment and occupy the full width
- tidy vertical spacing around the checkout area so it aligns with adjacent content

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68e10e507b608321844290f3ed5f07c6