### PR TITLE
Fix ML vision payload serialization

### DIFF
--- a/backend/src/PosBackend/Application/Services/MlClient.cs
+++ b/backend/src/PosBackend/Application/Services/MlClient.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Json;
 using Microsoft.Extensions.Configuration;
+using System.Text.Json.Serialization;
 
 namespace PosBackend.Application.Services;
 
@@ -17,8 +18,14 @@ public class MlClient
     public record AnomalyRequest(string Sku, decimal Price, decimal Quantity);
     public record AnomalyResult(bool IsAnomaly, double Score, string? Reason);
 
-    public record VisionRequest(string ProductId, IEnumerable<double> Embedding);
-    public record VisionResult(string PredictedLabel, double Confidence, bool IsMatch);
+    public record VisionRequest(
+        [property: JsonPropertyName("product_id")] string ProductId,
+        [property: JsonPropertyName("embedding")] IEnumerable<double> Embedding);
+
+    public record VisionResult(
+        [property: JsonPropertyName("predicted_label")] string PredictedLabel,
+        [property: JsonPropertyName("confidence")] double Confidence,
+        [property: JsonPropertyName("is_match")] bool IsMatch);
 
     public async Task<AnomalyResult?> PredictAnomalyAsync(AnomalyRequest request, CancellationToken cancellationToken)
     {

--- a/backend/tests/PosBackend.Tests/MlClientTests.cs
+++ b/backend/tests/PosBackend.Tests/MlClientTests.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using PosBackend.Application.Services;
+using Xunit;
+
+namespace PosBackend.Tests;
+
+public class MlClientTests
+{
+    [Fact]
+    public async Task PredictVisionAsync_SendsSnakeCasePayloadAndParsesResponse()
+    {
+        string? recordedContent = null;
+
+        var handler = new DelegateHttpMessageHandler(async request =>
+        {
+            recordedContent = await request.Content!.ReadAsStringAsync();
+            var response = new MlClient.VisionResult("apple", 0.87, true);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(response)
+            };
+        });
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["MlService:BaseUrl"] = "http://localhost"
+            })
+            .Build();
+
+        var client = new MlClient(new HttpClient(handler), configuration);
+        var request = new MlClient.VisionRequest("ABC123", new[] { 0.1, 0.2 });
+
+        var result = await client.PredictVisionAsync(request, CancellationToken.None);
+
+        Assert.NotNull(recordedContent);
+        using var document = JsonDocument.Parse(recordedContent!);
+        var root = document.RootElement;
+        Assert.Equal("ABC123", root.GetProperty("product_id").GetString());
+
+        var embedding = root.GetProperty("embedding").EnumerateArray().Select(e => e.GetDouble()).ToArray();
+        Assert.Equal(new[] { 0.1, 0.2 }, embedding);
+
+        Assert.NotNull(result);
+        Assert.Equal("apple", result!.PredictedLabel);
+        Assert.Equal(0.87, result.Confidence);
+        Assert.True(result.IsMatch);
+    }
+
+    private sealed class DelegateHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, Task<HttpResponseMessage>> _handler;
+
+        public DelegateHttpMessageHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> handler)
+        {
+            _handler = handler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return _handler(request);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- decorate the ML vision request/response records with JSON property names so payloads use snake_case
- add a regression test that verifies the vision request is serialized correctly and responses still deserialize

## Testing
- dotnet test *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e126ed940083219d216f7f84201465