### PR TITLE
Handle validation errors with ValidationProblemDetails

### DIFF
--- a/backend/src/PosBackend/Features/Purchases/PurchasesController.cs
+++ b/backend/src/PosBackend/Features/Purchases/PurchasesController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using PosBackend.Application.Requests;
@@ -153,7 +154,18 @@ public class PurchasesController : ControllerBase
 
         if (errors.Count > 0)
         {
-            return ValidationProblem(errors);
+            var validationProblem = new ValidationProblemDetails
+            {
+                Status = StatusCodes.Status400BadRequest,
+                Title = "One or more validation errors occurred."
+            };
+
+            foreach (var error in errors)
+            {
+                validationProblem.Errors.Add(error.Key, error.Value);
+            }
+
+            return ValidationProblem(validationProblem);
         }
 
         await _db.PurchaseOrders.AddAsync(purchase, cancellationToken);


### PR DESCRIPTION
## Summary
- construct and return a ValidationProblemDetails when purchase item validation errors are detected
- ensure the error response retains HTTP 400 semantics and includes the field-level messages

## Testing
- dotnet publish PosBackend.csproj -c Release *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e13f2faa3483219894ca9749a08591