### PR TITLE
Ensure backend Docker build fails on restore/publish errors

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,9 +1,9 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ./src/PosBackend/PosBackend.csproj ./
-RUN dotnet restore PosBackend.csproj || true
+RUN dotnet restore PosBackend.csproj
 COPY ./src/PosBackend ./
-RUN dotnet publish PosBackend.csproj -c Release -o /app/publish || true
+RUN dotnet publish PosBackend.csproj -c Release -o /app/publish
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0
 WORKDIR /app


### PR DESCRIPTION
## Summary
- remove the `|| true` fallbacks from the backend Dockerfile restore and publish steps so build failures stop the image build

## Testing
- docker compose build backend *(fails in this environment: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68e141705e508321a64da1c7de39cfaf