### PR TITLE
Ensure purchase validation uses ValidationProblemDetails

### DIFF
--- a/backend/src/PosBackend/Features/Purchases/PurchasesController.cs
+++ b/backend/src/PosBackend/Features/Purchases/PurchasesController.cs
@@ -154,16 +154,11 @@ public class PurchasesController : ControllerBase
 
         if (errors.Count > 0)
         {
-            var validationProblem = new ValidationProblemDetails
+            var validationProblem = new ValidationProblemDetails(errors)
             {
                 Status = StatusCodes.Status400BadRequest,
                 Title = "One or more validation errors occurred."
             };
-
-            foreach (var error in errors)
-            {
-                validationProblem.Errors.Add(error.Key, error.Value);
-            }
 
             return ValidationProblem(validationProblem);
         }


### PR DESCRIPTION
## Summary
- construct a ValidationProblemDetails object from the aggregated purchase line errors before returning a validation problem response so the 400 payload preserves field details

## Testing
- dotnet publish backend/PosBackend.sln *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e14480457083219bb3ccf34a980829