### PR TITLE
Fix casing in purchasing metrics migration

### DIFF
--- a/backend/src/PosBackend/Infrastructure/Data/Migrations/20240701000003_AddPurchasingAndProfitMetrics.cs
+++ b/backend/src/PosBackend/Infrastructure/Data/Migrations/20240701000003_AddPurchasingAndProfitMetrics.cs
@@ -34,11 +34,11 @@ namespace PosBackend.Infrastructure.Data.Migrations
                 nullable: true);
 
             migrationBuilder.DropColumn(
-                name: "total_cost",
+                name: "TotalCost",
                 table: "purchase_orders");
 
             migrationBuilder.DropColumn(
-                name: "currency",
+                name: "Currency",
                 table: "purchase_orders");
 
             migrationBuilder.AddColumn<Guid>(
@@ -146,13 +146,13 @@ namespace PosBackend.Infrastructure.Data.Migrations
                         name: "FK_purchase_order_lines_products_ProductId",
                         column: x => x.ProductId,
                         principalTable: "products",
-                        principalColumn: "id",
+                        principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                     table.ForeignKey(
                         name: "FK_purchase_order_lines_purchase_orders_PurchaseOrderId",
                         column: x => x.PurchaseOrderId,
                         principalTable: "purchase_orders",
-                        principalColumn: "id",
+                        principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 });
 
@@ -176,7 +176,7 @@ namespace PosBackend.Infrastructure.Data.Migrations
                 table: "purchase_orders",
                 column: "created_by_user_id",
                 principalTable: "users",
-                principalColumn: "id");
+                principalColumn: "Id");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
@@ -253,7 +253,7 @@ namespace PosBackend.Infrastructure.Data.Migrations
                 table: "transaction_lines");
 
             migrationBuilder.AddColumn<string>(
-                name: "currency",
+                name: "Currency",
                 table: "purchase_orders",
                 type: "character varying(3)",
                 maxLength: 3,
@@ -261,7 +261,7 @@ namespace PosBackend.Infrastructure.Data.Migrations
                 defaultValue: "USD");
 
             migrationBuilder.AddColumn<decimal>(
-                name: "total_cost",
+                name: "TotalCost",
                 table: "purchase_orders",
                 type: "numeric(14,2)",
                 nullable: false,


### PR DESCRIPTION
## Summary
- update the purchasing metrics migration to drop and re-add the legacy columns using the original casing
- align foreign key principal column names with the quoted identifiers that exist in PostgreSQL so the migration can run

## Testing
- dotnet ef database update --project backend/src/PosBackend/PosBackend.csproj --startup-project backend/src/PosBackend/PosBackend.csproj

------
https://chatgpt.com/codex/tasks/task_e_68e16212fe148321abd0fe8475e726e9