### PR TITLE
Ensure SkiaSharp native assets are published

### DIFF
--- a/backend/src/PosBackend/PosBackend.csproj
+++ b/backend/src/PosBackend/PosBackend.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="QuestPDF" Version="2023.12.1" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.6" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add the SkiaSharp Linux native assets package to the backend project so libSkiaSharp.so is included in publish output

## Testing
- dotnet restore
- dotnet publish src/PosBackend/PosBackend.csproj -c Release


------
https://chatgpt.com/codex/tasks/task_e_68e1999d91dc8321a5cceeb34768b4f6