### PR TITLE
Update SkiaSharp native asset package

### DIFF
--- a/backend/src/PosBackend/PosBackend.csproj
+++ b/backend/src/PosBackend/PosBackend.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="QuestPDF" Version="2023.12.1" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.6" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.7" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- update the PosBackend project to use SkiaSharp.NativeAssets.Linux.NoDependencies 2.88.7 so that the native libSkiaSharp binaries are included in publish output

## Testing
- dotnet restore
- dotnet publish -c Release


------
https://chatgpt.com/codex/tasks/task_e_68e19c0aa7208321a3fce187e5836f72