### PR TITLE
Add Linux HarfBuzz native assets for backend

### DIFF
--- a/backend/src/PosBackend/PosBackend.csproj
+++ b/backend/src/PosBackend/PosBackend.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="QuestPDF" Version="2023.12.1" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="2.8.2.1" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.7" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- add the HarfBuzzSharp.NativeAssets.Linux package so the backend publish includes the native HarfBuzz library alongside QuestPDF

## Testing
- dotnet restore backend/src/PosBackend/PosBackend.csproj
- dotnet publish backend/src/PosBackend/PosBackend.csproj -c Release

------
https://chatgpt.com/codex/tasks/task_e_68e1a35d936083218f8f07585622a754