### PR TITLE
Set QuestPDF license for backend

### DIFF
--- a/backend/src/PosBackend/Program.cs
+++ b/backend/src/PosBackend/Program.cs
@@ -4,12 +4,15 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using QuestPDF.Infrastructure;
 using PosBackend;
 using PosBackend.Application.Services;
 using PosBackend.Infrastructure.Data;
 using Npgsql;
 
 var builder = WebApplication.CreateBuilder(args);
+
+QuestPDF.Settings.License = LicenseType.Community;
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();


### PR DESCRIPTION
## Summary
- import QuestPDF infrastructure namespace in Program.cs
- configure the QuestPDF license to use the community tier during backend startup

## Testing
- dotnet build backend/src/PosBackend/PosBackend.csproj *(fails: `dotnet` command not found in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e22af1e90483219c9177f84a500617