### PR TITLE
Prevent transaction line back reference serialization

### DIFF
--- a/backend/src/PosBackend/Domain/Entities/TransactionLine.cs
+++ b/backend/src/PosBackend/Domain/Entities/TransactionLine.cs
@@ -1,8 +1,11 @@
+using System.Text.Json.Serialization;
+
 namespace PosBackend.Domain.Entities;
 
 public class TransactionLine : BaseEntity
 {
     public Guid TransactionId { get; set; }
+    [JsonIgnore]
     public PosTransaction? Transaction { get; set; }
     public Guid ProductId { get; set; }
     public Product? Product { get; set; }


### PR DESCRIPTION
## Summary
- add a JSON ignore attribute to the transaction navigation property on TransactionLine to avoid back-reference serialization

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e22daa144c832183df7c3072c13186