### PR TITLE
Make SKU optional across POS flows

### DIFF
--- a/frontend/src/components/pos/CartPanel.tsx
+++ b/frontend/src/components/pos/CartPanel.tsx
@@ -167,7 +167,7 @@ export function CartPanel({ onClear, highlightedItemId, onQuantityConfirm }: Car
                 <div className="flex items-start justify-between">
                   <div>
                     <p className="font-semibold">{item.name}</p>
-                    <p className="text-xs text-slate-500">{item.sku}</p>
+                    <p className="text-xs text-slate-500">{item.sku?.trim() || '—'}</p>
                   </div>
                   <button
                     type="button"

--- a/frontend/src/components/pos/ProductGrid.tsx
+++ b/frontend/src/components/pos/ProductGrid.tsx
@@ -39,7 +39,7 @@ export function ProductGrid({ onScan }: ProductGridProps) {
     addItem({
       productId: product.id,
       name: product.name,
-      sku: product.sku,
+      sku: product.sku?.trim() || undefined,
       barcode: product.barcode,
       priceUsd: product.priceUsd,
       priceLbp: product.priceLbp,
@@ -72,7 +72,7 @@ export function ProductGrid({ onScan }: ProductGridProps) {
               <div className="flex items-start justify-between gap-1">
                 <div className="min-w-0">
                   <p className="truncate font-medium">{product.name}</p>
-                  <span className="text-[0.7rem] text-slate-500">{product.sku}</span>
+                  <span className="text-[0.7rem] text-slate-500">{product.sku?.trim() || '—'}</span>
                 </div>
                 {product.isPinned && (
                   <Badge className="shrink-0 bg-amber-100 text-amber-900 dark:bg-amber-900/50 dark:text-amber-200">

--- a/frontend/src/lib/ProductsService.ts
+++ b/frontend/src/lib/ProductsService.ts
@@ -4,7 +4,7 @@ import { useAuthStore } from '../stores/authStore';
 
 export interface Product {
   id: string;
-  sku: string;
+  sku?: string | null;
   name: string;
   barcode: string;
   priceUsd: number;
@@ -20,7 +20,7 @@ export interface Product {
 }
 
 export interface CreateProductInput {
-  sku: string;
+  sku?: string;
   name: string;
   barcode: string;
   price: number;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -17,7 +17,7 @@ export type ProductCurrency = 'USD' | 'LBP';
 
 export interface ProductResponseDto {
   id: string;
-  sku: string;
+  sku?: string | null;
   name: string;
   barcode: string;
   priceUsd: number;
@@ -30,7 +30,7 @@ export interface ProductResponseDto {
 
 export interface ProductMutationPayload {
   name: string;
-  sku: string;
+  sku?: string;
   barcode: string;
   price: number;
   currency?: ProductCurrency;

--- a/frontend/src/pages/InventoryPage.tsx
+++ b/frontend/src/pages/InventoryPage.tsx
@@ -92,7 +92,6 @@ export function InventoryPage() {
 
     if (
       !name ||
-      !sku ||
       !barcode ||
       !categoryName ||
       !Number.isFinite(parsedPrice) ||
@@ -104,12 +103,12 @@ export function InventoryPage() {
     return {
       payload: {
         name,
-        sku,
         barcode,
         categoryName,
         price: parsedPrice,
         currency: values.currency,
-        isPinned: values.isPinned
+        isPinned: values.isPinned,
+        ...(sku ? { sku } : {})
       }
     };
   };
@@ -153,12 +152,12 @@ export function InventoryPage() {
       await togglePinnedProduct.mutateAsync({
         id: product.id,
         name: product.name,
-        sku: product.sku,
         barcode: product.barcode,
         categoryName: product.categoryName ?? product.category,
         price: product.priceUsd,
         currency: 'USD',
-        isPinned: !product.isPinned
+        isPinned: !product.isPinned,
+        ...(product.sku && product.sku.trim() ? { sku: product.sku } : {})
       });
       setBanner({
         type: 'success',
@@ -266,7 +265,9 @@ export function InventoryPage() {
                   productsQuery.data.map((product) => (
                     <tr key={product.id} className="text-slate-700 dark:text-slate-200">
                       <td className="px-4 py-3 text-sm font-medium">{product.name}</td>
-                      <td className="px-4 py-3 text-xs uppercase text-slate-500">{product.sku}</td>
+                      <td className="px-4 py-3 text-xs uppercase text-slate-500">
+                        {product.sku?.trim() || '—'}
+                      </td>
                       <td className="px-4 py-3 text-sm text-slate-500">{product.barcode}</td>
                       <td className="px-4 py-3 text-sm text-slate-500">
                         <div className="flex flex-col">
@@ -354,7 +355,7 @@ export function InventoryPage() {
           submitLabel={t('inventoryUpdateAction')}
           values={{
             name: dialog.product.name,
-            sku: dialog.product.sku,
+            sku: dialog.product.sku ?? '',
             barcode: dialog.product.barcode,
             categoryName: dialog.product.categoryName ?? dialog.product.category ?? '',
             price: dialog.product.priceUsd.toString(),
@@ -448,7 +449,6 @@ function ProductFormDialog({
               value={formValues.sku}
               onChange={handleChange('sku')}
               placeholder={t('inventorySkuPlaceholder')}
-              required
             />
           </div>
         </div>

--- a/frontend/src/pages/POSPage.tsx
+++ b/frontend/src/pages/POSPage.tsx
@@ -36,7 +36,7 @@ interface CheckoutResponse extends BalanceResponse {
 
 interface ProductResponse {
   id: string;
-  sku: string;
+  sku?: string | null;
   name: string;
   barcode: string;
   priceUsd: number;
@@ -103,7 +103,7 @@ export function POSPage() {
       addItem({
         productId: product.id,
         name: product.name,
-        sku: product.sku,
+        sku: product.sku?.trim() || undefined,
         barcode: product.barcode,
         priceUsd: product.priceUsd,
         priceLbp: product.priceLbp,
@@ -111,7 +111,8 @@ export function POSPage() {
         discountPercent: 0
       });
       setLastAddedItemId(product.id);
-      setLastScan(`${product.name} (${product.sku})`);
+      const displaySku = product.sku?.trim();
+      setLastScan(displaySku ? `${product.name} (${displaySku})` : product.name);
       setBarcode('');
       if (product.isFlagged) {
         setOverrideRequired(true);
@@ -314,7 +315,12 @@ export function POSPage() {
             </Button>
           </form>
           <div className="flex-1 overflow-hidden">
-            <ProductGrid onScan={(product) => setLastScan(`${product.name} (${product.sku})`)} />
+            <ProductGrid
+              onScan={(product) => {
+                const displaySku = product.sku?.trim();
+                setLastScan(displaySku ? `${product.name} (${displaySku})` : product.name);
+              }}
+            />
           </div>
         </div>
         <div className="flex h-[calc(100vh-11rem)] max-w-md flex-col gap-3 lg:justify-between">

--- a/frontend/src/pages/PurchasesPage.tsx
+++ b/frontend/src/pages/PurchasesPage.tsx
@@ -105,7 +105,7 @@ export function PurchasesPage() {
               productId: product.id,
               barcode: product.barcode,
               name: product.name,
-              sku: product.sku,
+              sku: product.sku?.trim() ?? '',
               categoryName: product.categoryName ?? product.category ?? '',
               quantity: '1',
               unitCost: (product.averageCostUsd ?? product.priceUsd ?? 0).toString(),
@@ -204,7 +204,7 @@ export function PurchasesPage() {
       }
       const salePrice = Number(item.salePriceUsd);
       if (!item.isExisting) {
-        if (!item.name.trim() || !item.sku.trim() || !item.categoryName.trim()) {
+        if (!item.name.trim() || !item.categoryName.trim()) {
           setBanner({ type: 'error', message: t('purchasesValidationError') });
           return;
         }
@@ -213,7 +213,10 @@ export function PurchasesPage() {
         productId: item.productId,
         barcode: item.barcode,
         name: item.isExisting ? undefined : item.name.trim(),
-        sku: item.isExisting ? undefined : item.sku.trim(),
+        sku:
+          item.isExisting || !item.sku.trim()
+            ? undefined
+            : item.sku.trim(),
         categoryName: item.isExisting ? undefined : item.categoryName.trim(),
         quantity,
         unitCost,
@@ -373,11 +376,10 @@ export function PurchasesPage() {
                       </td>
                       <td className="px-4 py-3">
                         <Input
-                          value={item.sku}
+                          value={item.isExisting && !item.sku.trim() ? '—' : item.sku}
                           onChange={(event) => handleItemChange(item.id, 'sku', event.target.value)}
                           placeholder={t('inventorySkuPlaceholder')}
                           disabled={item.isExisting}
-                          required={!item.isExisting}
                         />
                       </td>
                       <td className="px-4 py-3">

--- a/frontend/src/stores/cartStore.ts
+++ b/frontend/src/stores/cartStore.ts
@@ -5,7 +5,7 @@ import { playCartBeep } from '../lib/sounds';
 export interface CartItem {
   productId: string;
   name: string;
-  sku: string;
+  sku?: string | null;
   barcode: string;
   priceUsd: number;
   priceLbp: number;
@@ -91,7 +91,24 @@ export const useCartStore = create<CartState>()(
       setLastAddedItemId: (productId) => set({ lastAddedItemId: productId })
     }),
     {
-      name: 'aurora-cart'
+      name: 'aurora-cart',
+      version: 1,
+      migrate: (persistedState) => {
+        if (!persistedState || typeof persistedState !== 'object') {
+          return persistedState;
+        }
+        const state = persistedState as CartState;
+        const items = Array.isArray(state.items)
+          ? state.items.map((item) => ({
+              ...item,
+              sku: item.sku && String(item.sku).trim() ? String(item.sku) : undefined
+            }))
+          : [];
+        return {
+          ...state,
+          items
+        } satisfies CartState;
+      }
     }
   )
 );


### PR DESCRIPTION
## Summary
- make SKU optional in shared DTOs, services, and inventory forms while trimming any provided value
- drop SKU requirements from purchase drafting and ensure payloads exclude blank strings
- render fallback text when SKU is missing across POS components and migrate persisted cart data safely

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e230832ecc8321bf4370072ebfed26