### PR TITLE
Add checkout line DTO to prevent serialization cycles

### DIFF
--- a/backend/src/PosBackend/Application/Responses/CheckoutLineResponse.cs
+++ b/backend/src/PosBackend/Application/Responses/CheckoutLineResponse.cs
@@ -1,0 +1,54 @@
+using PosBackend.Domain.Entities;
+
+namespace PosBackend.Application.Responses;
+
+public class CheckoutLineResponse
+{
+    public Guid Id { get; set; }
+    public Guid ProductId { get; set; }
+    public string ProductName { get; set; } = string.Empty;
+    public string? ProductSku { get; set; }
+    public string? ProductBarcode { get; set; }
+    public Guid? PriceRuleId { get; set; }
+    public PriceRuleType? PriceRuleType { get; set; }
+    public string? PriceRuleDescription { get; set; }
+    public decimal Quantity { get; set; }
+    public decimal BaseUnitPriceUsd { get; set; }
+    public decimal BaseUnitPriceLbp { get; set; }
+    public decimal UnitPriceUsd { get; set; }
+    public decimal UnitPriceLbp { get; set; }
+    public decimal DiscountPercent { get; set; }
+    public decimal TotalUsd { get; set; }
+    public decimal TotalLbp { get; set; }
+    public decimal CostUsd { get; set; }
+    public decimal CostLbp { get; set; }
+    public decimal ProfitUsd { get; set; }
+    public decimal ProfitLbp { get; set; }
+
+    public static CheckoutLineResponse FromEntity(TransactionLine line)
+    {
+        return new CheckoutLineResponse
+        {
+            Id = line.Id,
+            ProductId = line.ProductId,
+            ProductName = line.Product?.Name ?? string.Empty,
+            ProductSku = line.Product?.Sku,
+            ProductBarcode = line.Product?.Barcode,
+            PriceRuleId = line.PriceRuleId,
+            PriceRuleType = line.PriceRule?.RuleType,
+            PriceRuleDescription = line.PriceRule?.Description,
+            Quantity = line.Quantity,
+            BaseUnitPriceUsd = line.BaseUnitPriceUsd,
+            BaseUnitPriceLbp = line.BaseUnitPriceLbp,
+            UnitPriceUsd = line.UnitPriceUsd,
+            UnitPriceLbp = line.UnitPriceLbp,
+            DiscountPercent = line.DiscountPercent,
+            TotalUsd = line.TotalUsd,
+            TotalLbp = line.TotalLbp,
+            CostUsd = line.CostUsd,
+            CostLbp = line.CostLbp,
+            ProfitUsd = line.ProfitUsd,
+            ProfitLbp = line.ProfitLbp
+        };
+    }
+}

--- a/backend/src/PosBackend/Application/Responses/CheckoutResponse.cs
+++ b/backend/src/PosBackend/Application/Responses/CheckoutResponse.cs
@@ -1,5 +1,3 @@
-using PosBackend.Domain.Entities;
-
 namespace PosBackend.Application.Responses;
 
 public class CheckoutResponse
@@ -13,7 +11,7 @@ public class CheckoutResponse
     public decimal BalanceUsd { get; set; }
     public decimal BalanceLbp { get; set; }
     public decimal ExchangeRate { get; set; }
-    public IEnumerable<TransactionLine> Lines { get; set; } = new List<TransactionLine>();
+    public IEnumerable<CheckoutLineResponse> Lines { get; set; } = new List<CheckoutLineResponse>();
     public string ReceiptPdfBase64 { get; set; } = string.Empty;
     public bool RequiresOverride { get; set; }
     public string? OverrideReason { get; set; }

--- a/backend/src/PosBackend/Application/Services/CartPricingService.cs
+++ b/backend/src/PosBackend/Application/Services/CartPricingService.cs
@@ -66,6 +66,8 @@ public class CartPricingService
                 ProfitUsd = _currencyService.RoundUsd(profitUsd),
                 ProfitLbp = _currencyService.RoundLbp(profitLbp)
             };
+            line.Product = product;
+            line.PriceRule = priceRule;
             lines.Add(line);
             totalUsd += line.TotalUsd;
             totalLbp += line.TotalLbp;

--- a/backend/src/PosBackend/Domain/Entities/TransactionLine.cs
+++ b/backend/src/PosBackend/Domain/Entities/TransactionLine.cs
@@ -8,8 +8,10 @@ public class TransactionLine : BaseEntity
     [JsonIgnore]
     public PosTransaction? Transaction { get; set; }
     public Guid ProductId { get; set; }
+    [JsonIgnore]
     public Product? Product { get; set; }
     public Guid? PriceRuleId { get; set; }
+    [JsonIgnore]
     public PriceRule? PriceRule { get; set; }
     public decimal Quantity { get; set; }
     public decimal BaseUnitPriceUsd { get; set; }


### PR DESCRIPTION
## Summary
- add JsonIgnore attributes to transaction line navigation properties to prevent circular serialization
- introduce CheckoutLineResponse DTO and update checkout/return endpoints to emit it
- ensure pricing service keeps navigation data populated for downstream consumers

## Testing
- ⚠️ `dotnet build backend/src/PosBackend/PosBackend.csproj` *(fails: dotnet CLI not available in container)*
- ⚠️ `dotnet test backend/tests/PosBackend.Tests/PosBackend.Tests.csproj` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e235acbd4083219d2ceae449a37603