### PR TITLE
Improve POS layout scroll handling

### DIFF
--- a/frontend/src/components/pos/ProductGrid.tsx
+++ b/frontend/src/components/pos/ProductGrid.tsx
@@ -59,7 +59,7 @@ export function ProductGrid({ onScan }: ProductGridProps) {
         className="text-base"
       />
       <div className="relative flex-1 overflow-hidden">
-        <div className="grid max-h-[26rem] grid-cols-2 gap-2.5 overflow-y-auto pr-1 sm:max-h-[30rem] sm:grid-cols-2 md:grid-cols-3 lg:max-h-[32rem] lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+        <div className="grid min-h-0 grid-cols-2 gap-2.5 overflow-y-auto pr-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
           {data?.map((product) => (
             <button
               key={product.id}

--- a/frontend/src/pages/POSPage.tsx
+++ b/frontend/src/pages/POSPage.tsx
@@ -273,7 +273,7 @@ export function POSPage() {
   };
 
   return (
-    <div className="flex min-h-screen flex-col gap-3 bg-slate-100 p-4 lg:p-6 dark:bg-slate-950">
+    <div className="grid h-screen grid-rows-[auto_auto_1fr] gap-3 overflow-hidden bg-slate-100 p-4 lg:p-6 dark:bg-slate-950">
       <TopBar
         onLogout={logout}
         lastScan={lastScan}
@@ -300,43 +300,45 @@ export function POSPage() {
           disabled={overrideRequired}
         />
       </div>
-      <div className="grid gap-3 lg:grid-cols-[1.75fr_1fr] xl:grid-cols-[1.65fr_1fr]">
-        <div className="flex min-h-0 flex-col gap-3 lg:pr-2">
-          <form onSubmit={handleScanSubmit} className="flex items-center gap-2.5">
-            <Input
-              id="barcode-input"
-              ref={barcodeInputRef}
-              value={barcode}
-              onChange={(event) => setBarcode(event.target.value)}
-              placeholder={t('barcodePlaceholder')}
-              className="text-base"
-            />
-            <Button type="submit" size="sm">
-              Scan
-            </Button>
-          </form>
-          <div className="flex-1 overflow-hidden">
-            <ProductGrid
-              onScan={(product) => {
-                const displaySku = product.sku?.trim();
-                setLastScan(displaySku ? `${product.name} (${displaySku})` : product.name);
-              }}
-            />
+      <div className="row-start-3 min-h-0">
+        <div className="grid min-h-0 gap-3 overflow-hidden lg:grid-cols-[1.75fr_1fr] xl:grid-cols-[1.65fr_1fr]">
+          <div className="flex min-h-0 flex-col gap-3 lg:pr-2">
+            <form onSubmit={handleScanSubmit} className="flex items-center gap-2.5">
+              <Input
+                id="barcode-input"
+                ref={barcodeInputRef}
+                value={barcode}
+                onChange={(event) => setBarcode(event.target.value)}
+                placeholder={t('barcodePlaceholder')}
+                className="text-base"
+              />
+              <Button type="submit" size="sm">
+                Scan
+              </Button>
+            </form>
+            <div className="flex-1 overflow-hidden">
+              <ProductGrid
+                onScan={(product) => {
+                  const displaySku = product.sku?.trim();
+                  setLastScan(displaySku ? `${product.name} (${displaySku})` : product.name);
+                }}
+              />
+            </div>
           </div>
-        </div>
-        <div className="flex h-[calc(100vh-11rem)] max-w-md flex-col gap-3 lg:justify-between">
-          <div className="flex-1 overflow-hidden">
-            <CartPanel
-              onClear={clear}
-              highlightedItemId={lastAddedItemId}
-              onQuantityConfirm={() => {
-                setLastAddedItemId(null);
-                barcodeInputRef.current?.focus();
-              }}
-            />
-          </div>
-          <div className="mt-auto pt-1">
-            <ReceiptPreview />
+          <div className="flex min-h-0 max-w-md flex-col gap-3 overflow-hidden lg:justify-between">
+            <div className="flex-1 overflow-hidden">
+              <CartPanel
+                onClear={clear}
+                highlightedItemId={lastAddedItemId}
+                onQuantityConfirm={() => {
+                  setLastAddedItemId(null);
+                  barcodeInputRef.current?.focus();
+                }}
+              />
+            </div>
+            <div className="mt-auto pt-1">
+              <ReceiptPreview />
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- lock the POS page layout to a viewport-sized grid so header and tender areas stay fixed
- ensure both main columns respect min-h-0 and overflow handling so only inner panels scroll
- update the product grid container to rely on overflow-y scrolling without max-height limits

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68e246ec64a8832198e4f5574e091dec