### PR TITLE
Persist store profile name across sessions

### DIFF
--- a/frontend/src/lib/SettingsService.ts
+++ b/frontend/src/lib/SettingsService.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiFetch } from './api';
 import { useAuthStore } from '../stores/authStore';
-import { DEFAULT_STORE_NAME, useStoreProfileStore } from '../stores/storeProfileStore';
+import { useStoreProfileStore } from '../stores/storeProfileStore';
 
 export interface StoreProfileResponse {
   id: string;
@@ -30,9 +30,6 @@ export function useStoreProfileQuery() {
     },
     onSuccess: (data) => {
       setName(data.name);
-    },
-    onError: () => {
-      setName(DEFAULT_STORE_NAME);
     }
   });
 }

--- a/frontend/src/stores/storeProfileStore.ts
+++ b/frontend/src/stores/storeProfileStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 export const DEFAULT_STORE_NAME = 'Aurora Market';
 
@@ -7,7 +8,15 @@ interface StoreProfileState {
   setName: (name: string) => void;
 }
 
-export const useStoreProfileStore = create<StoreProfileState>((set) => ({
-  name: DEFAULT_STORE_NAME,
-  setName: (name: string) => set({ name: name.trim() || DEFAULT_STORE_NAME })
-}));
+export const useStoreProfileStore = create<StoreProfileState>()(
+  persist(
+    (set) => ({
+      name: DEFAULT_STORE_NAME,
+      setName: (name: string) => {
+        const trimmedName = name.trim();
+        set({ name: trimmedName || DEFAULT_STORE_NAME });
+      }
+    }),
+    { name: 'store-profile' }
+  )
+);


### PR DESCRIPTION
## Summary
- persist the store profile name in the zustand store so it survives reloads
- continue trimming names while updating the store state through zustand setters
- stop resetting the hydrated store name when the store profile query errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e24d513ddc83218fe051a57b091dd6