### PR TITLE
Refine POS checkout layout

### DIFF
--- a/frontend/src/pages/POSPage.tsx
+++ b/frontend/src/pages/POSPage.tsx
@@ -284,7 +284,7 @@ export function POSPage() {
         onNavigateSettings={canManageInventory ? () => navigate('/settings') : undefined}
       />
       <div className="row-start-2 min-h-0">
-        <div className="grid min-h-0 gap-3 overflow-hidden lg:grid-cols-[minmax(0,1.75fr)_minmax(0,1fr)] xl:grid-cols-[minmax(0,1.65fr)_minmax(0,1fr)]">
+        <div className="grid min-h-0 gap-3 overflow-hidden lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1.15fr)] xl:grid-cols-[minmax(0,1.45fr)_minmax(0,1.15fr)]">
           <div className="flex min-h-0 flex-col gap-3 lg:pr-2">
             <form onSubmit={handleScanSubmit} className="flex items-center gap-2.5">
               <Input
@@ -308,8 +308,8 @@ export function POSPage() {
               />
             </div>
           </div>
-          <div className="flex min-h-0 flex-col gap-3 overflow-hidden lg:max-w-md">
-            <div className="rounded-xl bg-white p-4 shadow-sm dark:bg-slate-900">
+          <div className="grid min-h-0 gap-3 overflow-hidden grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+            <div className="min-h-0 overflow-hidden rounded-xl bg-white p-4 shadow-sm dark:bg-slate-900">
               <TenderPanel
                 paidUsdText={paidUsdText}
                 paidLbpText={paidLbpText}
@@ -326,7 +326,7 @@ export function POSPage() {
                 disabled={overrideRequired}
               />
             </div>
-            <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden">
+            <div className="flex min-h-0 flex-col gap-3 overflow-hidden">
               <div className="flex-1 overflow-hidden">
                 <CartPanel
                   onClear={clear}


### PR DESCRIPTION
## Summary
- convert the POS checkout column into a responsive grid so the tender and cart panels can sit side by side on wide screens
- adjust grid ratios and wrappers to maintain min-h-0 and overflow handling while keeping the receipt anchored below the cart

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e25365a2448321a5ed1c59c1c8d87b