### PR TITLE
Align POS cart and receipt panels side by side

### DIFF
--- a/frontend/src/components/pos/ReceiptPreview.tsx
+++ b/frontend/src/components/pos/ReceiptPreview.tsx
@@ -11,17 +11,17 @@ export function ReceiptPreview() {
   const storeName = useStoreProfileStore((state) => state.name);
 
   return (
-    <Card className="bg-slate-50 text-sm dark:bg-slate-900">
+    <Card className="flex h-full flex-col bg-slate-50 text-sm dark:bg-slate-900">
       <CardHeader className="pb-2">
         <CardTitle className="text-base font-semibold text-slate-700 dark:text-slate-100">
           {t('receiptPreview')}
         </CardTitle>
       </CardHeader>
-      <CardContent className="space-y-3">
+      <CardContent className="flex flex-1 flex-col space-y-3 overflow-y-auto">
         <div className="text-center text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
           {storeName}
         </div>
-        <div className="max-h-32 space-y-2 overflow-y-auto pr-1">
+        <div className="flex-1 space-y-2 overflow-y-auto pr-1">
           {items.length > 0 ? (
             items.map((item) => (
               <div key={item.productId} className="flex items-start justify-between gap-2">

--- a/frontend/src/pages/POSPage.tsx
+++ b/frontend/src/pages/POSPage.tsx
@@ -326,8 +326,8 @@ export function POSPage() {
                 disabled={overrideRequired}
               />
             </div>
-            <div className="flex min-h-0 flex-col gap-3 overflow-hidden">
-              <div className="flex-1 overflow-hidden">
+            <div className="grid min-h-0 grid-cols-1 gap-3 overflow-hidden lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+              <div className="min-h-0 overflow-hidden">
                 <CartPanel
                   onClear={clear}
                   highlightedItemId={lastAddedItemId}
@@ -337,7 +337,7 @@ export function POSPage() {
                   }}
                 />
               </div>
-              <div className="shrink-0 pt-1">
+              <div className="min-h-0 overflow-hidden">
                 <ReceiptPreview />
               </div>
             </div>


### PR DESCRIPTION
## Summary
- replace the POS sidebar column layout with a responsive grid so the cart and receipt can sit side by side on large screens
- allow the receipt preview card to stretch to the full allotted height and scroll internally

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e25d95f1f08321995303b5b167b222