### PR TITLE
Adjust POS layout grid to favor checkout side

### DIFF
--- a/frontend/src/pages/POSPage.tsx
+++ b/frontend/src/pages/POSPage.tsx
@@ -284,7 +284,7 @@ export function POSPage() {
         onNavigateSettings={canManageInventory ? () => navigate('/settings') : undefined}
       />
       <div className="row-start-2 min-h-0">
-        <div className="grid min-h-0 gap-3 overflow-hidden lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1.15fr)] xl:grid-cols-[minmax(0,1.45fr)_minmax(0,1.15fr)]">
+        <div className="grid min-h-0 gap-3 overflow-hidden lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1.4fr)] xl:grid-cols-[minmax(0,1.05fr)_minmax(0,1.5fr)]">
           <div className="flex min-h-0 flex-col gap-3 lg:pr-2">
             <form onSubmit={handleScanSubmit} className="flex items-center gap-2.5">
               <Input
@@ -299,7 +299,7 @@ export function POSPage() {
                 Scan
               </Button>
             </form>
-            <div className="flex-1 overflow-hidden">
+            <div className="flex-1 min-h-0 overflow-hidden">
               <ProductGrid
                 onScan={(product) => {
                   const displaySku = product.sku?.trim();


### PR DESCRIPTION
## Summary
- update the POS page grid ratios at large breakpoints to shift more space to the checkout rail
- keep the product column wrapper constrained with `min-h-0 flex-1` so its grid continues to scroll correctly

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68e27a2eeac883219068c24e0d00056f