### PR TITLE
Ensure POS panels stretch to full height

### DIFF
--- a/frontend/src/pages/POSPage.tsx
+++ b/frontend/src/pages/POSPage.tsx
@@ -283,9 +283,9 @@ export function POSPage() {
         onNavigateInventory={canManageInventory ? () => navigate('/inventory') : undefined}
         onNavigateSettings={canManageInventory ? () => navigate('/settings') : undefined}
       />
-      <div className="row-start-2 min-h-0">
-        <div className="grid min-h-0 gap-3 overflow-hidden lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1.4fr)] xl:grid-cols-[minmax(0,1.05fr)_minmax(0,1.5fr)]">
-          <div className="flex min-h-0 flex-col gap-3 lg:pr-2">
+      <div className="row-start-2 h-full min-h-0">
+        <div className="grid h-full min-h-0 gap-3 overflow-hidden lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1.4fr)] xl:grid-cols-[minmax(0,1.05fr)_minmax(0,1.5fr)]">
+          <div className="flex h-full min-h-0 flex-col gap-3 lg:pr-2">
             <form onSubmit={handleScanSubmit} className="flex items-center gap-2.5">
               <Input
                 id="barcode-input"
@@ -308,7 +308,7 @@ export function POSPage() {
               />
             </div>
           </div>
-          <div className="grid min-h-0 gap-3 overflow-hidden grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+          <div className="grid h-full min-h-0 grid-cols-1 gap-3 overflow-hidden lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
             <div className="min-h-0 overflow-hidden rounded-xl bg-white p-4 shadow-sm dark:bg-slate-900">
               <TenderPanel
                 paidUsdText={paidUsdText}
@@ -326,8 +326,8 @@ export function POSPage() {
                 disabled={overrideRequired}
               />
             </div>
-            <div className="grid min-h-0 grid-cols-1 gap-3 overflow-hidden lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
-              <div className="min-h-0 overflow-hidden">
+            <div className="grid h-full min-h-0 auto-rows-[minmax(0,1fr)] grid-cols-1 gap-3 overflow-hidden lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+              <div className="flex h-full min-h-0 overflow-hidden">
                 <CartPanel
                   onClear={clear}
                   highlightedItemId={lastAddedItemId}
@@ -337,7 +337,7 @@ export function POSPage() {
                   }}
                 />
               </div>
-              <div className="min-h-0 overflow-hidden">
+              <div className="flex h-full min-h-0 overflow-hidden">
                 <ReceiptPreview />
               </div>
             </div>


### PR DESCRIPTION
## Summary
- stretch the POS page content grids to consume the full viewport height
- allow the cart and receipt panels to flex to their allotted space while keeping their contents scrollable

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68e2ad2987588321a6d7aa272038342c