### PR TITLE
Ensure POS panels fill their grid columns

### DIFF
--- a/frontend/src/components/pos/CartPanel.tsx
+++ b/frontend/src/components/pos/CartPanel.tsx
@@ -146,7 +146,7 @@ export function CartPanel({ onClear, highlightedItemId, onQuantityConfirm }: Car
   };
 
   return (
-    <Card className="flex h-full flex-col bg-slate-50 dark:bg-slate-900">
+    <Card className="flex h-full w-full flex-col bg-slate-50 dark:bg-slate-900">
       <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <CardTitle>{t('cart')}</CardTitle>
         <Button type="button" className="bg-slate-600 hover:bg-slate-500" onClick={onClear}>

--- a/frontend/src/components/pos/ReceiptPreview.tsx
+++ b/frontend/src/components/pos/ReceiptPreview.tsx
@@ -11,7 +11,7 @@ export function ReceiptPreview() {
   const storeName = useStoreProfileStore((state) => state.name);
 
   return (
-    <Card className="flex h-full flex-col bg-slate-50 text-sm dark:bg-slate-900">
+    <Card className="flex h-full w-full flex-col bg-slate-50 text-sm dark:bg-slate-900">
       <CardHeader className="pb-2">
         <CardTitle className="text-base font-semibold text-slate-700 dark:text-slate-100">
           {t('receiptPreview')}

--- a/frontend/src/pages/POSPage.tsx
+++ b/frontend/src/pages/POSPage.tsx
@@ -327,7 +327,7 @@ export function POSPage() {
               />
             </div>
             <div className="grid h-full min-h-0 auto-rows-[minmax(0,1fr)] grid-cols-1 gap-3 overflow-hidden lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
-              <div className="flex h-full min-h-0 overflow-hidden">
+              <div className="flex h-full min-h-0 w-full overflow-hidden">
                 <CartPanel
                   onClear={clear}
                   highlightedItemId={lastAddedItemId}
@@ -337,7 +337,7 @@ export function POSPage() {
                   }}
                 />
               </div>
-              <div className="flex h-full min-h-0 overflow-hidden">
+              <div className="flex h-full min-h-0 w-full overflow-hidden">
                 <ReceiptPreview />
               </div>
             </div>


### PR DESCRIPTION
## Summary
- update the POS page layout wrappers so the cart and receipt columns stretch to fill each grid cell
- extend the CartPanel and ReceiptPreview cards to span their container width for consistent spacing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2b4073e9483218e46d888a3a9e83a