### PR TITLE
Refine POS product grid layout

### DIFF
--- a/frontend/src/components/pos/ProductGrid.tsx
+++ b/frontend/src/components/pos/ProductGrid.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ProductsService, Product } from '../../lib/ProductsService';
 import { Input } from '../ui/input';
-import { Card } from '../ui/card';
+import { Card, CardContent, CardHeader } from '../ui/card';
 import { Badge } from '../ui/badge';
 import { cn, formatCurrency } from '../../lib/utils';
 import { useCartStore } from '../../stores/cartStore';
@@ -25,31 +25,14 @@ export function ProductGrid({ onScan }: ProductGridProps) {
     return () => clearTimeout(handler);
   }, [term]);
 
-  const trimmedTerm = debouncedTerm.trim();
-  const showPinnedShelf = trimmedTerm.length === 0;
-
   const {
-    data: catalogData,
-    isFetching: isCatalogFetching
-  } = ProductsService.useSearchProducts(debouncedTerm, {
-    pinnedOnly: false
-  });
-
-  const {
-    data: pinnedData,
+    data: pinnedProducts = [],
     isFetching: isPinnedFetching
-  } = ProductsService.useSearchProducts('', {
-    pinnedOnly: true,
-    enabled: showPinnedShelf
+  } = ProductsService.useSearchProducts(debouncedTerm, {
+    pinnedOnly: true
   });
 
-  const pinnedProducts = pinnedData ?? [];
-  const showPinnedEmptyState = showPinnedShelf && !isPinnedFetching && pinnedProducts.length === 0;
-
-  const catalogProducts = catalogData ?? [];
-  const visibleCatalogProducts = showPinnedShelf
-    ? catalogProducts.filter((product) => !product.isPinned)
-    : catalogProducts;
+  const showPinnedEmptyState = !isPinnedFetching && pinnedProducts.length === 0;
 
   const handleAdd = (product: Product) => {
     addItem({
@@ -70,7 +53,7 @@ export function ProductGrid({ onScan }: ProductGridProps) {
       key={product.id}
       onClick={() => handleAdd(product)}
       className={cn(
-        'rounded-md border border-slate-200 bg-white p-2.5 text-left text-sm shadow-sm transition focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-800',
+        'w-full rounded-md border border-slate-200 bg-white p-2.5 text-left text-sm shadow-sm transition focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-800',
         'hover:border-emerald-500'
       )}
     >
@@ -93,53 +76,34 @@ export function ProductGrid({ onScan }: ProductGridProps) {
   );
 
   return (
-    <div className="flex h-full flex-col gap-2.5">
-      <Input
-        placeholder={t('searchProducts')}
-        value={term}
-        onChange={(event) => setTerm(event.target.value)}
-        autoFocus
-        className="text-base"
-      />
-      <div className="flex min-h-0 flex-1 flex-col gap-2.5">
-        {showPinnedShelf && (
-          <Card className="flex h-48 flex-col overflow-hidden border border-slate-200 !p-0 shadow-sm dark:border-slate-700">
-            <div className="flex items-center justify-between gap-2.5 px-2.5 pt-2.5">
-              <p className="text-xs font-semibold uppercase tracking-wide text-slate-600 dark:text-slate-300">
-                {t('pinnedShelfTitle', 'Pinned shelf')}
-              </p>
-              <button
-                type="button"
-                onClick={() => setTerm('')}
-                className="text-xs font-medium text-emerald-600 hover:text-emerald-700 dark:text-emerald-400 dark:hover:text-emerald-300"
-              >
-                {t('pinnedShelfSeeAll', 'See all pinned')}
-              </button>
+    <Card className="flex h-full flex-col">
+      <CardHeader className="mb-4 flex-col items-stretch gap-3 p-0">
+        <Input
+          placeholder={t('searchProducts')}
+          value={term}
+          onChange={(event) => setTerm(event.target.value)}
+          autoFocus
+          className="w-full text-base"
+        />
+      </CardHeader>
+      <CardContent className="flex-1 overflow-y-auto space-y-3 px-4 pb-4">
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-600 dark:text-slate-300">
+          {t('pinnedShelfTitle', 'Pinned shelf')}
+        </p>
+        <div className="grid grid-cols-2 gap-2.5 pr-1 sm:grid-cols-3 lg:grid-cols-4">
+          {pinnedProducts.map((product) => renderProductButton(product))}
+          {showPinnedEmptyState && (
+            <div className="col-span-full rounded-md border border-dashed border-slate-200 p-4 text-center text-xs text-slate-500 dark:border-slate-700">
+              {t('pinnedProductsEmpty', 'No curated products yet. Try searching to see the full catalog.')}
             </div>
-            <div className="flex-1 overflow-y-auto px-2.5 pb-2.5">
-              <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-3 lg:grid-cols-4">
-                {pinnedProducts.map((product) => renderProductButton(product))}
-                {showPinnedEmptyState && (
-                  <Card className="col-span-full text-center text-xs text-slate-500">
-                    {t('pinnedProductsEmpty', 'No curated products yet. Try searching to see the full catalog.')}
-                  </Card>
-                )}
-                {isPinnedFetching && (
-                  <Card className="col-span-full text-center text-xs text-slate-500">Loading…</Card>
-                )}
-              </div>
+          )}
+          {isPinnedFetching && (
+            <div className="col-span-full rounded-md border border-dashed border-slate-200 p-4 text-center text-xs text-slate-500 dark:border-slate-700">
+              Loading…
             </div>
-          </Card>
-        )}
-        <div className="relative flex-1 overflow-hidden">
-          <div className="grid min-h-0 grid-cols-2 gap-2.5 overflow-y-auto pr-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
-            {visibleCatalogProducts.map((product) => renderProductButton(product))}
-            {isCatalogFetching && (
-              <Card className="col-span-full text-center text-xs text-slate-500">Loading…</Card>
-            )}
-          </div>
+          )}
         </div>
-      </div>
-    </div>
+      </CardContent>
+    </Card>
   );
 }


### PR DESCRIPTION
## Summary
- fetch only pinned products in the POS product grid using the debounced search term
- collapse the layout into a single full-height card with a scrollable content area to align with the checkout column
- keep pinned product empty and loading states within the new scroll area

## Testing
- pnpm --dir frontend lint

------
https://chatgpt.com/codex/tasks/task_e_68e2b48b39e48321ab757b4bd8b763be