### PR TITLE
Rename Inventory controller namespace to avoid conflict

### DIFF
--- a/backend/src/PosBackend/Features/Inventories/InventoryController.cs
+++ b/backend/src/PosBackend/Features/Inventories/InventoryController.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using PosBackend.Application.Responses;
 using PosBackend.Infrastructure.Data;
 
-namespace PosBackend.Features.Inventory;
+namespace PosBackend.Features.Inventories;
 
 [ApiController]
 [Route("api/inventory")]


### PR DESCRIPTION
## Summary
- rename the Inventory feature folder and controller namespace to `PosBackend.Features.Inventories`
- update the namespace declaration to prevent collisions with the domain `Inventory` entity

## Testing
- dotnet build backend/PosBackend.sln *(fails: dotnet command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3a82700f483218682c453850026a4