### PR TITLE
Focus barcode input on POS page load

### DIFF
--- a/frontend/src/components/pos/ProductGrid.tsx
+++ b/frontend/src/components/pos/ProductGrid.tsx
@@ -82,7 +82,6 @@ export function ProductGrid({ onScan }: ProductGridProps) {
           placeholder={t('searchProducts')}
           value={term}
           onChange={(event) => setTerm(event.target.value)}
-          autoFocus
           className="w-full text-base"
         />
       </CardHeader>

--- a/frontend/src/pages/POSPage.tsx
+++ b/frontend/src/pages/POSPage.tsx
@@ -76,6 +76,10 @@ export function POSPage() {
   const barcodeInputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
+    barcodeInputRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
     const handler = (event: KeyboardEvent) => {
       if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'k') {
         event.preventDefault();


### PR DESCRIPTION
## Summary
- prevent the product search input from auto-focusing when the POS loads
- focus the barcode scanner input on POS page mount so scanning can begin immediately

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3ae2ec91483218a3bc589bc76aa6f