### PR TITLE
Ensure barcode field regains focus

### DIFF
--- a/frontend/src/pages/POSPage.tsx
+++ b/frontend/src/pages/POSPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -75,9 +75,13 @@ export function POSPage() {
   const [overrideReason, setOverrideReason] = useState<string | null>(null);
   const barcodeInputRef = useRef<HTMLInputElement | null>(null);
 
-  useEffect(() => {
+  const focusBarcodeInput = useCallback(() => {
     barcodeInputRef.current?.focus();
   }, []);
+
+  useEffect(() => {
+    focusBarcodeInput();
+  }, [focusBarcodeInput]);
 
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {
@@ -118,6 +122,7 @@ export function POSPage() {
       const displaySku = product.sku?.trim();
       setLastScan(displaySku ? `${product.name} (${displaySku})` : product.name);
       setBarcode('');
+      focusBarcodeInput();
       if (product.isFlagged) {
         setOverrideRequired(true);
         setOverrideReason(product.flagReason ?? 'Anomaly detected');
@@ -337,7 +342,7 @@ export function POSPage() {
                   highlightedItemId={lastAddedItemId}
                   onQuantityConfirm={() => {
                     setLastAddedItemId(null);
-                    barcodeInputRef.current?.focus();
+                    focusBarcodeInput();
                   }}
                 />
               </div>


### PR DESCRIPTION
## Summary
- add a reusable helper to focus the barcode input when the POS page mounts
- refocus the barcode field after successful scans and quantity confirmations to keep the scanner ready

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3b734b1548321801f5cc536f33d2a