### PR TITLE
Fix duplicate focus handler declaration on POS page

### DIFF
--- a/frontend/src/pages/POSPage.tsx
+++ b/frontend/src/pages/POSPage.tsx
@@ -87,14 +87,6 @@ export function POSPage() {
   const pendingEditableTimeoutRef = useRef<number | null>(null);
 
   const focusBarcodeInput = useCallback(() => {
-    barcodeInputRef.current?.focus();
-  }, []);
-
-  useEffect(() => {
-    focusBarcodeInput();
-  }, [focusBarcodeInput]);
-
-  const focusBarcodeInput = useCallback(() => {
     const element = barcodeInputRef.current;
     if (!element) {
       return;


### PR DESCRIPTION
## Summary
- remove the redundant focusBarcodeInput hook on the POS page to avoid duplicate declarations
- rely on the enhanced focus helper that also preserves cursor position when focusing the barcode field

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3d4d96f1c8321851da584d3e9524c