### PR TITLE
Set default inventory reorder point to three units

### DIFF
--- a/backend/src/PosBackend/Domain/Entities/Inventory.cs
+++ b/backend/src/PosBackend/Domain/Entities/Inventory.cs
@@ -5,10 +5,10 @@ public class Inventory : BaseEntity
     public Guid ProductId { get; set; }
     public Product? Product { get; set; }
     public decimal QuantityOnHand { get; set; }
-    public decimal ReorderPoint { get; set; }
+    public decimal ReorderPoint { get; set; } = 3;
     public decimal ReorderQuantity { get; set; }
     public decimal AverageCostUsd { get; set; }
     public decimal AverageCostLbp { get; set; }
     public DateTimeOffset? LastRestockedAt { get; set; }
-    public bool IsReorderAlarmEnabled { get; set; }
+    public bool IsReorderAlarmEnabled { get; set; } = true;
 }

--- a/backend/src/PosBackend/Features/Purchases/PurchasesController.cs
+++ b/backend/src/PosBackend/Features/Purchases/PurchasesController.cs
@@ -456,20 +456,20 @@ public class PurchasesController : ControllerBase
     private async Task UpdateInventoryAsync(Product product, decimal quantity, decimal unitCostUsd, decimal exchangeRate, CancellationToken cancellationToken)
     {
         var inventory = await _db.Inventories.FirstOrDefaultAsync(i => i.ProductId == product.Id, cancellationToken);
-            if (inventory is null)
+        if (inventory is null)
+        {
+            inventory = new InventoryEntity
             {
-                inventory = new InventoryEntity
-                {
-                    ProductId = product.Id,
-                    QuantityOnHand = 0,
-                    ReorderPoint = 0,
-                    ReorderQuantity = 0,
-                    IsReorderAlarmEnabled = false,
-                    AverageCostUsd = unitCostUsd,
-                    AverageCostLbp = _currencyService.ConvertUsdToLbp(unitCostUsd, exchangeRate),
-                    LastRestockedAt = DateTimeOffset.UtcNow
-                };
-                await _db.Inventories.AddAsync(inventory, cancellationToken);
+                ProductId = product.Id,
+                QuantityOnHand = 0,
+                ReorderPoint = 3,
+                ReorderQuantity = 0,
+                IsReorderAlarmEnabled = true,
+                AverageCostUsd = unitCostUsd,
+                AverageCostLbp = _currencyService.ConvertUsdToLbp(unitCostUsd, exchangeRate),
+                LastRestockedAt = DateTimeOffset.UtcNow
+            };
+            await _db.Inventories.AddAsync(inventory, cancellationToken);
         }
 
         var existingQty = inventory.QuantityOnHand;

--- a/backend/src/PosBackend/Infrastructure/Data/Migrations/20250215000000_SetDefaultInventoryReorderPoint.cs
+++ b/backend/src/PosBackend/Infrastructure/Data/Migrations/20250215000000_SetDefaultInventoryReorderPoint.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using PosBackend.Infrastructure.Data;
+
+#nullable disable
+
+namespace PosBackend.Infrastructure.Data.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20250215000000_SetDefaultInventoryReorderPoint")]
+    public partial class SetDefaultInventoryReorderPoint : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("UPDATE \"inventories\" SET \"IsReorderAlarmEnabled\" = TRUE WHERE \"ReorderPoint\" = 0 AND \"IsReorderAlarmEnabled\" = FALSE;");
+            migrationBuilder.Sql("UPDATE \"inventories\" SET \"ReorderPoint\" = 3 WHERE \"ReorderPoint\" = 0;");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("UPDATE \"inventories\" SET \"ReorderPoint\" = 0, \"IsReorderAlarmEnabled\" = FALSE WHERE \"ReorderPoint\" = 3;");
+        }
+    }
+}

--- a/backend/tests/PosBackend.Tests/InventoryTests.cs
+++ b/backend/tests/PosBackend.Tests/InventoryTests.cs
@@ -1,0 +1,16 @@
+using PosBackend.Domain.Entities;
+using Xunit;
+
+namespace PosBackend.Tests;
+
+public class InventoryTests
+{
+    [Fact]
+    public void Inventory_Defaults_EnableReorderAlarmAtThreeUnits()
+    {
+        var inventory = new Inventory();
+
+        Assert.Equal(3m, inventory.ReorderPoint);
+        Assert.True(inventory.IsReorderAlarmEnabled);
+    }
+}


### PR DESCRIPTION
## Summary
- default inventory reorder alarms to trigger at three units for new inventory records
- backfill existing inventory rows to adopt the new threshold when they were still on the old default
- add coverage to ensure the entity defaults stay aligned with the alarm requirement

## Testing
- dotnet test *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e54a4e88148321bf7d2f47dc89a54e