### PR TITLE
Ensure auth store handles missing session storage

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,9 @@
 
 This directory will house in-depth architecture notes, ADRs, and integration guides as the project evolves across milestones.
 
+- [Desktop packaging guide](./desktop-app.md) — explains how to ship the React
+  frontend inside Electron/Tauri without major code changes.
+
 > ℹ️ **Compose & environment files**
 >
 > Docker Compose resolves environment variables relative to the directory containing the compose file. Because the project keeps the primary `.env` in the repository root while the compose file lives in `infra/`, pass the root file explicitly when running Compose (e.g., `docker compose --env-file .env -f infra/docker-compose.yml up -d --build`).

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -1,0 +1,55 @@
+# Aurora POS desktop packaging guide
+
+This document answers the recurring question of whether the Aurora POS frontend
+requires major code changes to run inside a desktop container (such as Electron
+or Tauri) instead of a traditional web browser.
+
+## Do we need large code changes?
+
+No. The current frontend is a standard React + Vite single-page application.
+Both Electron and Tauri embed a browser runtime (Chromium/WebView2/WebKit), so
+the existing UI can load without modification. You mainly need to provide the
+HTML/JS bundle to the host shell.
+
+The recent auth-store update already avoids relying on `sessionStorage` when it
+is unavailable, which matches desktop runtimes that scope storage to the
+application lifetime. When the app process exits, the in-memory store is
+cleared, so users are prompted to log in again on the next launch—mirroring your
+"close and reopen the system" requirement.
+
+## Recommended integration steps
+
+1. **Choose a shell**: Electron offers mature Node.js integration, while Tauri
+   keeps the binary size small with a Rust backend. Pick whichever matches your
+   stack preferences.
+2. **Point the shell at the Vite build output**: Run `npm install` (once) and
+   then `npm run build` in `frontend/` to generate the production bundle in
+   `frontend/dist`. Configure your shell to load that directory as the main
+   window.
+3. **Bridge native APIs as needed**: If you later need file system, serial
+   device, or OS integration, expose those capabilities through Electron's main
+   process or Tauri commands. The React UI can call them over IPC without
+   requiring component rewrites.
+4. **Handle auto updates and installers**: Desktop distribution usually adds
+   packaging (MSIX/DMG/AppImage) and update flows. These are shell-level tasks
+   and do not require changing the React components.
+
+## Optional adjustments
+
+While not required, you can consider the following quality-of-life tweaks for a
+polished desktop build:
+
+- **Custom window chrome**: Implement draggable regions and close/minimize
+  buttons if you want to hide the native frame. CSS changes live in
+  `frontend/src` and work in both browser and desktop modes.
+- **Local configuration storage**: If you need persistence between launches,
+  switch the auth store (or other stores) to a file-backed storage exposed by
+  your shell instead of `sessionStorage`.
+- **Splash screen / loading indicator**: Desktop users often expect a splash
+  screen while the web assets load. This is configured in the shell, not the
+  React bundle.
+
+In short, converting Aurora POS into a desktop application is primarily an
+integration exercise. The React codebase already runs inside the embedded web
+view, so you can focus on packaging and optional desktop-only polish rather than
+large-scale frontend rewrites.

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -1,5 +1,6 @@
-import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { create, type StateCreator } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import type { StateStorage } from 'zustand/middleware';
 import { apiFetch, LoginResponse } from '../lib/api';
 
 interface AuthState {
@@ -12,42 +13,66 @@ interface AuthState {
   logout: () => void;
 }
 
-export const useAuthStore = create<AuthState>()(
-  persist(
-    (set) => ({
-      token: null,
-      displayName: null,
-      role: null,
-      isLoading: false,
-      error: null,
-      login: async (username: string, password: string) => {
-        try {
-          set({ isLoading: true, error: null });
-          const response = await apiFetch<LoginResponse>('/api/auth/login', {
-            method: 'POST',
-            body: JSON.stringify({ username, password })
-          });
-          set({
-            token: response.token,
-            displayName: response.displayName,
-            role: response.role,
-            isLoading: false
-          });
-        } catch (error) {
-          set({
-            error: error instanceof Error ? error.message : 'Login failed',
-            isLoading: false,
-            token: null,
-            displayName: null,
-            role: null
-          });
-          throw error;
-        }
-      },
-      logout: () => set({ token: null, displayName: null, role: null })
-    }),
-    {
-      name: 'aurora-auth'
+const createNoopStorage = (): StateStorage => ({
+  getItem: () => null,
+  setItem: () => undefined,
+  removeItem: () => undefined
+});
+
+const resolveSessionStorage = (): StateStorage => {
+  if (typeof window !== 'undefined' && window.sessionStorage) {
+    return window.sessionStorage;
+  }
+
+  if (typeof globalThis !== 'undefined') {
+    const { sessionStorage } = globalThis as unknown as {
+      sessionStorage?: StateStorage;
+    };
+
+    if (sessionStorage) {
+      return sessionStorage;
     }
-  )
+  }
+
+  return createNoopStorage();
+};
+
+const authStoreCreator: StateCreator<AuthState> = (set) => ({
+  token: null,
+  displayName: null,
+  role: null,
+  isLoading: false,
+  error: null,
+  login: async (username: string, password: string) => {
+    try {
+      set({ isLoading: true, error: null });
+      const response = await apiFetch<LoginResponse>('/api/auth/login', {
+        method: 'POST',
+        body: JSON.stringify({ username, password })
+      });
+      set({
+        token: response.token,
+        displayName: response.displayName,
+        role: response.role,
+        isLoading: false
+      });
+    } catch (error) {
+      set({
+        error: error instanceof Error ? error.message : 'Login failed',
+        isLoading: false,
+        token: null,
+        displayName: null,
+        role: null
+      });
+      throw error;
+    }
+  },
+  logout: () => set({ token: null, displayName: null, role: null })
+});
+
+export const useAuthStore = create<AuthState>()(
+  persist(authStoreCreator, {
+    name: 'aurora-auth',
+    storage: createJSONStorage(resolveSessionStorage)
+  })
 );


### PR DESCRIPTION
## Summary
- add a no-op storage implementation so the auth store can still use Zustand persistence when sessionStorage is unavailable
- always hydrate through sessionStorage when present, but fall back to in-memory persistence for desktop and server environments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6645b1f508321ba865129f02db3b7