### PR TITLE
Allow negative inventory quantities for backordered sales

### DIFF
--- a/backend/src/PosBackend/Features/Products/ProductsController.cs
+++ b/backend/src/PosBackend/Features/Products/ProductsController.cs
@@ -533,11 +533,6 @@ public class ProductsController : ControllerBase
             AddError(errors, nameof(request.ReorderPoint), "Reorder point cannot be negative.");
         }
 
-        if (request.QuantityOnHand is decimal quantityOnHand && quantityOnHand < 0)
-        {
-            AddError(errors, nameof(request.QuantityOnHand), "Quantity on hand cannot be negative.");
-        }
-
         request.WeightUnit = NormalizeOptional(request.WeightUnit)?.ToLowerInvariant();
         var allowedWeightUnits = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "kg", "g", "lb" };
         if (request.IsSoldByWeight)

--- a/backend/src/PosBackend/Features/Transactions/TransactionsController.cs
+++ b/backend/src/PosBackend/Features/Transactions/TransactionsController.cs
@@ -355,7 +355,7 @@ public class TransactionsController : ControllerBase
                 ?? await _db.Inventories.FirstOrDefaultAsync(i => i.ProductId == line.ProductId, cancellationToken);
             if (inventory is not null)
             {
-                inventory.QuantityOnHand = Math.Max(0, inventory.QuantityOnHand - line.Quantity);
+                inventory.QuantityOnHand -= line.Quantity;
             }
         }
 
@@ -583,7 +583,7 @@ public class TransactionsController : ControllerBase
                 var inventory = await _db.Inventories.FirstOrDefaultAsync(i => i.ProductId == line.ProductId, cancellationToken);
                 if (inventory is not null)
                 {
-                    inventory.QuantityOnHand = Math.Max(0, inventory.QuantityOnHand - line.Quantity);
+                    inventory.QuantityOnHand -= line.Quantity;
                 }
             }
 

--- a/backend/tests/PosBackend.Tests/ProductsControllerTests.cs
+++ b/backend/tests/PosBackend.Tests/ProductsControllerTests.cs
@@ -93,6 +93,33 @@ public class ProductsControllerTests
     }
 
     [Fact]
+    public async Task CreateProduct_AllowsNegativeQuantityOnHand()
+    {
+        await using var context = CreateContext();
+
+        var controller = CreateController(context);
+        var request = new CreateProductRequest
+        {
+            Name = "Backordered Item",
+            Barcode = "7777777777777",
+            Price = 1.25m,
+            Currency = "USD",
+            CategoryName = "Snacks",
+            QuantityOnHand = -2.5m
+        };
+
+        var result = await controller.CreateProduct(request, CancellationToken.None);
+
+        var created = Assert.IsType<CreatedAtActionResult>(result.Result);
+        var response = Assert.IsType<ProductResponse>(created.Value);
+        Assert.Equal(-2.5m, response.QuantityOnHand);
+
+        var storedInventory = await context.Inventories.AsNoTracking().FirstOrDefaultAsync(i => i.ProductId == response.Id);
+        Assert.NotNull(storedInventory);
+        Assert.Equal(-2.5m, storedInventory!.QuantityOnHand);
+    }
+
+    [Fact]
     public async Task CreateProduct_ReturnsValidationProblem_ForDuplicateSku()
     {
         await using var context = CreateContext();

--- a/backend/tests/PosBackend.Tests/TransactionsControllerApiTests.cs
+++ b/backend/tests/PosBackend.Tests/TransactionsControllerApiTests.cs
@@ -78,6 +78,46 @@ public class TransactionsControllerApiTests : IClassFixture<TransactionsApiFacto
     }
 
     [Fact]
+    public async Task Checkout_WhenStockIsInsufficient_AllowsNegativeInventory()
+    {
+        var client = _factory.CreateClient();
+
+        using var scope = _factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var tokenService = scope.ServiceProvider.GetRequiredService<JwtTokenService>();
+
+        var user = await context.Users.FirstAsync(u => u.Username == "cashier");
+        var inventory = await context.Inventories.Include(i => i.Product).FirstAsync();
+        inventory.QuantityOnHand = 0m;
+        await context.SaveChangesAsync();
+
+        var token = tokenService.CreateToken(user);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var request = new CheckoutRequest
+        {
+            ExchangeRate = 90000m,
+            PaidUsd = inventory.Product.PriceUsd,
+            Items = new[]
+            {
+                new CartItemRequest(inventory.ProductId, 1, null, null)
+            }
+        };
+
+        var response = await client.PostAsJsonAsync("/api/transactions/checkout", request);
+
+        response.EnsureSuccessStatusCode();
+
+        await using var verificationScope = _factory.Services.CreateAsyncScope();
+        var verificationContext = verificationScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var inventoryAfter = await verificationContext.Inventories
+            .AsNoTracking()
+            .FirstAsync(i => i.ProductId == inventory.ProductId);
+
+        Assert.Equal(-1m, inventoryAfter.QuantityOnHand);
+    }
+
+    [Fact]
     public async Task Checkout_WithTokenContainingOnlySubClaim_Succeeds()
     {
         var client = _factory.CreateClient();

--- a/frontend/src/pages/ProductsPage.tsx
+++ b/frontend/src/pages/ProductsPage.tsx
@@ -344,7 +344,7 @@ export function ProductsPage() {
       return { error: t('inventoryCostValidationError') };
     }
 
-    if (quantityText && (!Number.isFinite(parsedQuantity) || (parsedQuantity ?? 0) < 0)) {
+    if (quantityText && !Number.isFinite(parsedQuantity)) {
       return { error: t('inventoryStockValidationError') };
     }
 
@@ -919,7 +919,6 @@ function ProductFormDialog({
             <Input
               id="product-stock-quantity"
               type="number"
-              min="0"
               step="0.01"
               value={formValues.stockQuantity}
               onChange={handleChange('stockQuantity')}


### PR DESCRIPTION
### Motivation
- Allow selling items before their purchase arrives (backorders) so `QuantityOnHand` can go negative and inventory remains correct when items are sold before restock. 
- Current server-side validation and clamping prevented negative stock values and caused inventory to stay at zero instead of reflecting outstanding negative quantities. 
- Update the frontend product form validation so users can enter negative stock values when appropriate.

### Description
- Removed the server-side validation that rejected negative `QuantityOnHand` in `backend/src/PosBackend/Features/Products/ProductsController.cs`. 
- Stopped clamping inventory deductions to zero by changing `inventory.QuantityOnHand = Math.Max(0, inventory.QuantityOnHand - line.Quantity)` to `inventory.QuantityOnHand -= line.Quantity` in `backend/src/PosBackend/Features/Transactions/TransactionsController.cs` in both checkout/update code paths. 
- Relaxed product stock validation and removed the `min="0"` constraint in the UI by updating `frontend/src/pages/ProductsPage.tsx` so only numeric validation is enforced and negative values are allowed. 
- Added unit tests `CreateProduct_AllowsNegativeQuantityOnHand` and `Checkout_WhenStockIsInsufficient_AllowsNegativeInventory` to `backend/tests/PosBackend.Tests/ProductsControllerTests.cs` and `backend/tests/PosBackend.Tests/TransactionsControllerApiTests.cs` respectively to cover creating products with negative stock and checkout that drives inventory negative.

### Testing
- Added tests listed above but running them in this environment failed because `dotnet` is not available, with the command `dotnet test backend/tests/PosBackend.Tests/PosBackend.Tests.csproj --filter "CreateProduct_AllowsNegativeQuantityOnHand|Checkout_WhenStockIsInsufficient_AllowsNegativeInventory"` returning `/bin/bash: line 1: dotnet: command not found`. 
- The new tests are present and should be executed in CI (or a developer environment with the .NET SDK) to validate behavior when negative inventory is used. 
- Manual verification: updated frontend validation and backend logic changes were applied to the indicated files (`ProductsController.cs`, `TransactionsController.cs`, `ProductsPage.tsx`) and corresponding tests were added to the test project.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69cd0bee89d4832189873635f6ec2d3a)