### PR TITLE
Restore 90,000 change rate and add per-line refund support in POS cart

### DIFF
--- a/backend/src/PosBackend/Application/Services/CurrencyService.cs
+++ b/backend/src/PosBackend/Application/Services/CurrencyService.cs
@@ -6,7 +6,7 @@ namespace PosBackend.Application.Services;
 
 public class CurrencyService
 {
-    private const decimal ChangeIssuanceRate = 89000m;
+    private const decimal ChangeIssuanceRate = 90000m;
 
     private readonly ApplicationDbContext _db;
 

--- a/frontend/src/components/pos/CartPanel.tsx
+++ b/frontend/src/components/pos/CartPanel.tsx
@@ -65,6 +65,7 @@ export function CartPanel({
     subtotalUsd,
     subtotalLbp,
     setItemWaste,
+    setItemRefund,
     rate,
     holdCart,
   } = useCartStore();
@@ -459,6 +460,11 @@ export function CartPanel({
                         {t('cartManualOverrideApplied')}
                       </Badge>
                     )}
+                    {item.isRefund && (
+                      <Badge className="bg-rose-100 text-rose-900 dark:bg-rose-900/40 dark:text-rose-200">
+                        Refund
+                      </Badge>
+                    )}
                   </div>
                   <div className="flex items-center gap-2">
                     {canMarkWaste && (
@@ -474,6 +480,18 @@ export function CartPanel({
                         {item.isWaste ? t('cartUnmarkWaste') : t('cartMarkWaste')}
                       </button>
                     )}
+                    <button
+                      type="button"
+                      className={`rounded-full border px-3 py-1 text-xs font-semibold transition focus:outline-none focus:ring-2 focus:ring-offset-2 ${
+                        item.isRefund
+                          ? 'border-rose-300 bg-rose-50 text-rose-700 hover:bg-rose-100 focus:ring-rose-500 dark:border-rose-700 dark:bg-rose-900/40 dark:text-rose-200'
+                          : 'border-slate-300 bg-slate-50 text-slate-700 hover:bg-slate-100 focus:ring-slate-500 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100'
+                      }`}
+                      onClick={() => setItemRefund(item.lineId, !item.isRefund)}
+                      disabled={item.isWaste}
+                    >
+                      {item.isRefund ? 'Unrefund' : 'Refund'}
+                    </button>
                     <button
                       type="button"
                       className="flex h-8 w-8 items-center justify-center rounded-full border border-red-200 text-red-600 transition hover:border-red-300 hover:bg-red-50 hover:text-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 focus:ring-offset-white dark:border-red-500/40 dark:text-red-300 dark:hover:border-red-400 dark:hover:bg-red-900/30 dark:hover:text-red-200 dark:focus:ring-offset-slate-900"

--- a/frontend/src/pages/POSPage.tsx
+++ b/frontend/src/pages/POSPage.tsx
@@ -855,7 +855,8 @@ export function POSPage() {
         const payload: Record<string, unknown> = {
           productId: item.productId,
           quantity: item.quantity,
-          isWaste: item.isWaste
+          isWaste: item.isWaste,
+          isRefund: Boolean(item.isRefund)
         };
 
         if (item.discountPercent > 0) {

--- a/frontend/src/stores/cartStore.ts
+++ b/frontend/src/stores/cartStore.ts
@@ -76,6 +76,7 @@ export interface CartItem {
   discountPercent: number;
   isWaste: boolean;
   hasConfiguredPriceOverride: boolean;
+  isRefund?: boolean;
   manualTotalUsd?: number | null;
   manualTotalLbp?: number | null;
 }
@@ -107,6 +108,7 @@ interface CartState {
   updateDiscount: (lineId: string, discount: number) => void;
   removeItem: (lineId: string) => void;
   setItemWaste: (lineId: string, isWaste: boolean) => void;
+  setItemRefund: (lineId: string, isRefund: boolean) => void;
   setItemManualTotals: (
     lineId: string,
     totals: { totalUsd?: number | null; totalLbp?: number | null }
@@ -164,7 +166,8 @@ export const useCartStore = create<CartState>()(
             i.priceLbp === normalized.priceLbp &&
             i.basePriceUsd === normalized.basePriceUsd &&
             i.basePriceLbp === normalized.basePriceLbp &&
-            i.hasConfiguredPriceOverride === normalized.hasConfiguredPriceOverride
+            i.hasConfiguredPriceOverride === normalized.hasConfiguredPriceOverride &&
+            Boolean(i.isRefund) === Boolean(normalized.isRefund)
         );
         if (existingIndex >= 0) {
           set((state) => {
@@ -271,6 +274,17 @@ export const useCartStore = create<CartState>()(
           }
           items.push(updatedItem);
           return { items, lastAddedItemId: updatedItem.lineId };
+        });
+      },
+      setItemRefund: (lineId, isRefund) => {
+        set((state) => {
+          const index = state.items.findIndex((item) => item.lineId === lineId);
+          if (index === -1) {
+            return {};
+          }
+          const items = [...state.items];
+          items[index] = { ...items[index], isRefund };
+          return { items };
         });
       },
       setItemManualTotals: (lineId, totals) =>


### PR DESCRIPTION
### Motivation
- Restore the change issuance conversion rate to `90000` so negative-USD change is computed using the prior 90,000 LBP rate.
- Allow marking individual cart lines as refunds so a single invoice/checkout can contain mixed sale and refund lines.

### Description
- Updated `CurrencyService` to set `ChangeIssuanceRate` back to `90000m` so change conversion uses the restored rate.
- Extended the cart state with an `isRefund` field on `CartItem` and a new `setItemRefund` action in `useCartStore` to manage per-line refund state.
- Adjusted cart line merge logic to consider `isRefund` so refund and sale lines do not merge accidentally.
- UI changes in `CartPanel` add a Refund/Unrefund toggle and a refund badge, and `POSPage` now includes `isRefund` per line in the checkout payload so the backend can process mixed items in one invoice.

### Testing
- Frontend production build was executed with `npm --prefix frontend run build` and completed successfully.
- Backend unit tests (`dotnet test --filter CurrencyServiceTests`) could not be executed in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b2e5ef6ec832190fec5fd15b28f7b)