### PR TITLE
Subtract refunded lines from cart totals and include per-line refund flag in pricing requests

### DIFF
--- a/frontend/src/pages/POSPage.tsx
+++ b/frontend/src/pages/POSPage.tsx
@@ -201,7 +201,8 @@ export function POSPage() {
       const requestItem: PriceCartItemInput = {
         productId: item.productId,
         quantity: item.quantity,
-        isWaste: item.isWaste
+        isWaste: item.isWaste,
+        isRefund: Boolean(item.isRefund)
       };
 
       if (item.discountPercent > 0) {

--- a/frontend/src/stores/cartStore.ts
+++ b/frontend/src/stores/cartStore.ts
@@ -346,14 +346,15 @@ export const useCartStore = create<CartState>()(
           if (item.isWaste) {
             return total;
           }
+          const refundMultiplier = item.isRefund ? -1 : 1;
           if (item.manualTotalUsd !== null && item.manualTotalUsd !== undefined) {
-            return total + item.manualTotalUsd;
+            return total + item.manualTotalUsd * refundMultiplier;
           }
           if (item.manualTotalLbp !== null && item.manualTotalLbp !== undefined && rate > 0) {
-            return total + Math.round((item.manualTotalLbp / rate) * 100) / 100;
+            return total + (Math.round((item.manualTotalLbp / rate) * 100) / 100) * refundMultiplier;
           }
           const discountedPriceUsd = item.priceUsd * (1 - item.discountPercent / 100);
-          return total + discountedPriceUsd * item.quantity;
+          return total + discountedPriceUsd * item.quantity * refundMultiplier;
         }, 0);
       },
       subtotalLbp: () => {
@@ -369,14 +370,15 @@ export const useCartStore = create<CartState>()(
           if (item.isWaste) {
             return total;
           }
+          const refundMultiplier = item.isRefund ? -1 : 1;
           if (item.manualTotalLbp !== null && item.manualTotalLbp !== undefined) {
-            return total + item.manualTotalLbp;
+            return total + item.manualTotalLbp * refundMultiplier;
           }
           if (item.manualTotalUsd !== null && item.manualTotalUsd !== undefined) {
-            return total + Math.round(item.manualTotalUsd * rate);
-        }
-        const discountedPriceLbp = item.priceLbp * (1 - item.discountPercent / 100);
-        return total + discountedPriceLbp * item.quantity;
+            return total + Math.round(item.manualTotalUsd * rate) * refundMultiplier;
+          }
+          const discountedPriceLbp = item.priceLbp * (1 - item.discountPercent / 100);
+          return total + discountedPriceLbp * item.quantity * refundMultiplier;
       }, 0);
       },
       setLastAddedItemId: (lineId) => set({ lastAddedItemId: lineId }),


### PR DESCRIPTION
### Motivation
- Refunded cart lines should reduce the checkout total instead of being added to it, and pricing requests must inform the backend which lines are refunds.

### Description
- Send per-line `isRefund` in the pricing payload from `frontend/src/pages/POSPage.tsx` by adding `isRefund: Boolean(item.isRefund)` to each `PriceCartItemInput`.
- Update subtotal calculations in `frontend/src/stores/cartStore.ts` to apply a `refundMultiplier` (−1 for refunded lines, +1 otherwise) to manual USD/LBP totals and to standard discounted line totals for both `subtotalUsd` and `subtotalLbp`.
- Preserve existing behavior of skipping `isWaste` lines and honoring manual cart totals and currency rate conversions while applying the refund sign.

### Testing
- Ran lint via `npm -C frontend run lint` which completed successfully with a pre-existing unrelated warning in `frontend/src/pages/ProfitsPage.tsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b39c2b68c832190eb981e24d22891)