### PR TITLE
Fix Profits page ReferenceError caused by temporal dead zone

### DIFF
--- a/frontend/src/pages/ProfitsPage.tsx
+++ b/frontend/src/pages/ProfitsPage.tsx
@@ -768,6 +768,20 @@ export function ProfitsPage() {
     },
     [debtsQuery.data]
   );
+  const periodLabel =
+    scope === 'daily' || scope === 'custom'
+      ? t('profitPeriodDay')
+      : scope === 'weekly'
+        ? t('profitPeriodWeek')
+        : scope === 'monthly'
+          ? t('profitPeriodMonth')
+          : t('profitPeriodYear');
+  const selectedPeriodLabel =
+    scope === 'custom'
+      ? customRangeLabel
+      : selectedPeriodKey
+        ? formatPeriodSummaryLabel(scope, selectedPeriodKey, locale)
+        : undefined;
   const selectedPeriodDebt = useMemo(() => {
     if (!selectedPeriodLabel || debtsQuery.isLoading || debtsQuery.isError) {
       return { usd: 0, lbp: 0 };
@@ -855,20 +869,6 @@ export function ProfitsPage() {
       }).format(netProfitMargin),
     [locale, netProfitMargin]
   );
-  const periodLabel =
-    scope === 'daily' || scope === 'custom'
-      ? t('profitPeriodDay')
-      : scope === 'weekly'
-        ? t('profitPeriodWeek')
-        : scope === 'monthly'
-          ? t('profitPeriodMonth')
-          : t('profitPeriodYear');
-  const selectedPeriodLabel =
-    scope === 'custom'
-      ? customRangeLabel
-      : selectedPeriodKey
-        ? formatPeriodSummaryLabel(scope, selectedPeriodKey, locale)
-        : undefined;
   const placeholderRow =
     selectedPeriodLabel && isExplicitSelection && chartData.length === 0
       ? {


### PR DESCRIPTION
### Motivation
- Prevent a runtime crash (`ReferenceError: Cannot access 'L' before initialization`) where `selectedPeriodLabel` was referenced inside a `useMemo` before it was declared, caused by an initialization order (temporal dead zone) in `ProfitsPage`.

### Description
- Reordered the declarations so `periodLabel` and `selectedPeriodLabel` are defined before the `selectedPeriodDebt` `useMemo` that reads `selectedPeriodLabel`, preserving existing label logic and memo dependencies.

### Testing
- Ran `cd frontend && npm run lint -- src/pages/ProfitsPage.tsx` and the lint completed successfully; one unrelated pre-existing `react-hooks/exhaustive-deps` warning remains.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b3dfa5e0c8321b63964fbe0288297)